### PR TITLE
Update and lock versions

### DIFF
--- a/packages/abstractions/package.json
+++ b/packages/abstractions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/kiota-abstractions",
-    "version": "1.0.0-preview.3",
+    "version": "1.0.0-preview.4",
     "description": "Core abstractions for kiota generated libraries in TypeScript and JavaScript",
     "main": "dist/cjs/src/index.js",
     "files": [

--- a/packages/authentication/azure/package.json
+++ b/packages/authentication/azure/package.json
@@ -36,7 +36,7 @@
     "homepage": "https://github.com/microsoft/kiota-typescript#readme",
     "dependencies": {
         "@azure/core-auth": "^1.3.2",
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.4",
+        "@microsoft/kiota-abstractions": "1.0.0-preview.4",
         "tslib": "^2.3.1"
     }
 }

--- a/packages/authentication/azure/package.json
+++ b/packages/authentication/azure/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/kiota-authentication-azure",
-    "version": "1.0.0-preview.2",
+    "version": "1.0.0-preview.3",
     "description": "Authentication provider for Kiota using Azure Identity",
     "main": "dist/cjs/src/index.js",
     "module": "dist/es/src/index.js",
@@ -36,7 +36,7 @@
     "homepage": "https://github.com/microsoft/kiota-typescript#readme",
     "dependencies": {
         "@azure/core-auth": "^1.3.2",
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.3",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.4",
         "tslib": "^2.3.1"
     }
 }

--- a/packages/http/fetch/package.json
+++ b/packages/http/fetch/package.json
@@ -44,7 +44,7 @@
         "test:es": "tsc -b tsconfig.es.test.json && mocha 'dist/es/test/common/**/*.js'  --require  esm && mocha 'dist/es/test/node/**/*.js'  --require  esm"
     },
     "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.4",
+        "@microsoft/kiota-abstractions": "1.0.0-preview.4",
         "node-fetch": "^2.6.5",
         "tslib": "^2.3.1"
     }

--- a/packages/http/fetch/package.json
+++ b/packages/http/fetch/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/kiota-http-fetchlibrary",
-    "version": "1.0.0-preview.4",
+    "version": "1.0.0-preview.5",
     "description": "Kiota request adapter implementation with fetch",
     "keywords": [
         "Kiota",
@@ -44,7 +44,7 @@
         "test:es": "tsc -b tsconfig.es.test.json && mocha 'dist/es/test/common/**/*.js'  --require  esm && mocha 'dist/es/test/node/**/*.js'  --require  esm"
     },
     "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.3",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.4",
         "node-fetch": "^2.6.5",
         "tslib": "^2.3.1"
     }

--- a/packages/serialization/json/package.json
+++ b/packages/serialization/json/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/kiota-serialization-json",
-    "version": "1.0.0-preview.4",
+    "version": "1.0.0-preview.5",
     "description": "Implementation of Kiota Serialization interfaces for JSON",
     "main": "dist/cjs/src/index.js",
     "module": "dist/es/src/index.js",
@@ -36,7 +36,7 @@
     },
     "homepage": "https://github.com/microsoft/kiota-typescript#readme",
     "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.3",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.4",
         "tslib": "^2.3.1"
     }
 }

--- a/packages/serialization/json/package.json
+++ b/packages/serialization/json/package.json
@@ -36,7 +36,7 @@
     },
     "homepage": "https://github.com/microsoft/kiota-typescript#readme",
     "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.4",
+        "@microsoft/kiota-abstractions": "1.0.0-preview.4",
         "tslib": "^2.3.1"
     }
 }

--- a/packages/serialization/text/package.json
+++ b/packages/serialization/text/package.json
@@ -40,7 +40,7 @@
     },
     "homepage": "https://github.com/microsoft/kiota-typescript#readme",
     "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.4",
+        "@microsoft/kiota-abstractions": "1.0.0-preview.4",
         "tslib": "^2.3.1"
     }
 }

--- a/packages/serialization/text/package.json
+++ b/packages/serialization/text/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/kiota-serialization-text",
-    "version": "1.0.0-preview.3",
+    "version": "1.0.0-preview.4",
     "description": "Implementation of Kiota Serialization interfaces for text",
     "files": [
         "src",
@@ -40,7 +40,7 @@
     },
     "homepage": "https://github.com/microsoft/kiota-typescript#readme",
     "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.3",
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.4",
         "tslib": "^2.3.1"
     }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "test-kiota-typescript-libraries",
   "description": "",
-  "version": "0.0.1-preview.0",
+  "version": "0.0.1-preview.1",
   "main": "index.js",
   "private": true,
   "scripts": {
@@ -9,10 +9,10 @@
   },
   "dependencies": {
     "@azure/identity": "2.0.4",
-    "@microsoft/kiota-abstractions": "^1.0.0-preview.3",
-    "@microsoft/kiota-authentication-azure": "^1.0.0-preview.2",
-    "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.4",
-    "@microsoft/kiota-serialization-json": "^1.0.0-preview.4",
-    "@microsoft/kiota-serialization-text": "^1.0.0-preview.3"
+    "@microsoft/kiota-abstractions": "^1.0.0-preview.4",
+    "@microsoft/kiota-authentication-azure": "^1.0.0-preview.3",
+    "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.5",
+    "@microsoft/kiota-serialization-json": "^1.0.0-preview.5",
+    "@microsoft/kiota-serialization-text": "^1.0.0-preview.4"
   }
 }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -8,11 +8,11 @@
     "test:integrated": "mocha dist/cjs/tests/*.js"
   },
   "dependencies": {
-    "@azure/identity": "2.0.4",
-    "@microsoft/kiota-abstractions": "^1.0.0-preview.4",
-    "@microsoft/kiota-authentication-azure": "^1.0.0-preview.3",
-    "@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.5",
-    "@microsoft/kiota-serialization-json": "^1.0.0-preview.5",
-    "@microsoft/kiota-serialization-text": "^1.0.0-preview.4"
+    "@azure/identity": "^2.0.4",
+    "@microsoft/kiota-abstractions": "1.0.0-preview.4",
+    "@microsoft/kiota-authentication-azure": "1.0.0-preview.3",
+    "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.5",
+    "@microsoft/kiota-serialization-json": "1.0.0-preview.5",
+    "@microsoft/kiota-serialization-text": "1.0.0-preview.4"
   }
 }


### PR DESCRIPTION
Removing ^ before the version of abstractions packages in the dependency list of the implementation packages. 
This locks the implementation packages to a specific version of the abstraction package to manage breaking changes in preview versions. 