### PR TITLE
Adds test to validate queryparamters

### DIFF
--- a/packages/abstractions/test/common/requestInformation.ts
+++ b/packages/abstractions/test/common/requestInformation.ts
@@ -62,8 +62,30 @@ describe("RequestInformation", () => {
     const qs = new GetQueryParameters();
     qs.select = ["id", "displayName"];
     requestInformation.setQueryStringParametersFromRawObject(qs);
-    assert.equal(requestInformation.URL,
-      "http://localhost/me?%24select=id,displayName");
+    assert.equal(
+      requestInformation.URL,
+      "http://localhost/me?%24select=id,displayName"
+    );
+  });
+
+  it("Does not set empty select query parameter", () => {
+    const requestInformation = new RequestInformation();
+    requestInformation.pathParameters["baseurl"] = baseUrl;
+    requestInformation.urlTemplate = "http://localhost/me{?%24select}";
+    const qs = new GetQueryParameters();
+    qs.select = [];
+    requestInformation.setQueryStringParametersFromRawObject(qs);
+    assert.equal(requestInformation.URL, "http://localhost/me");
+  });
+
+  it("Does not set empty search query parameter", () => {
+    const requestInformation = new RequestInformation();
+    requestInformation.pathParameters["baseurl"] = baseUrl;
+    requestInformation.urlTemplate = "http://localhost/me{?%24select}";
+    const qs = new GetQueryParameters();
+    qs.search = "";
+    requestInformation.setQueryStringParametersFromRawObject(qs);
+    assert.equal(requestInformation.URL, "http://localhost/me");
   });
 
   it("Adds headers to requestInformation", () => {


### PR DESCRIPTION
Related to https://github.com/microsoft/kiota-abstractions-dotnet/pull/61

In summary this PR adds test to validate the empty collections and strings do not end up being added to the queryParameters of a request. 