### PR TITLE
Adds response headers to API error

### DIFF
--- a/packages/abstractions/package.json
+++ b/packages/abstractions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/kiota-abstractions",
-  "version": "1.0.0-preview.16",
+  "version": "1.0.0-preview.17",
   "description": "Core abstractions for kiota generated libraries in TypeScript and JavaScript",
   "main": "dist/cjs/src/index.js",
   "module": "dist/es/src/index.js",

--- a/packages/abstractions/src/apiError.ts
+++ b/packages/abstractions/src/apiError.ts
@@ -3,4 +3,10 @@ export class ApiError extends Error {
   public constructor(message?: string) {
     super(message);
   }
+
+  /** The status code for the error. */
+  public responseStatusCode?: number;
+
+  /** The Response Headers. */
+  public responseHeaders: Record<string, string[]> = {};
 }

--- a/packages/authentication/azure/package.json
+++ b/packages/authentication/azure/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/microsoft/kiota-typescript#readme",
   "dependencies": {
     "@azure/core-auth": "^1.3.2",
-    "@microsoft/kiota-abstractions": "1.0.0-preview.16",
+    "@microsoft/kiota-abstractions": "1.0.0-preview.17",
     "@opentelemetry/api": "^1.2.0",
     "tslib": "^2.3.1"
   },

--- a/packages/authentication/spfx/package.json
+++ b/packages/authentication/spfx/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/microsoft/kiota-typescript#readme",
   "dependencies": {
-    "@microsoft/kiota-abstractions": "1.0.0-preview.16",
+    "@microsoft/kiota-abstractions": "1.0.0-preview.17",
     "@microsoft/sp-http": "^1.15.2",
     "@opentelemetry/api": "^1.2.0",
     "tslib": "^2.3.1"

--- a/packages/http/fetch/package.json
+++ b/packages/http/fetch/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-http-fetchlibrary",
-	"version": "1.0.0-preview.15",
+	"version": "1.0.0-preview.16",
 	"description": "Kiota request adapter implementation with fetch",
 	"keywords": [
 		"Kiota",
@@ -38,7 +38,7 @@
 		"test:cjs": "mocha 'dist/cjs/test/common/**/*.js' && mocha  'dist/cjs/test/node/**/*.js'"
 	},
 	"dependencies": {
-		"@microsoft/kiota-abstractions": "1.0.0-preview.16",
+		"@microsoft/kiota-abstractions": "1.0.0-preview.17",
 		"@opentelemetry/api": "^1.2.0",
 		"node-fetch": "^2.6.5",
 		"tslib": "^2.3.1"

--- a/packages/serialization/form/package.json
+++ b/packages/serialization/form/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/microsoft/kiota-typescript#readme",
   "dependencies": {
-    "@microsoft/kiota-abstractions": "1.0.0-preview.16",
+    "@microsoft/kiota-abstractions": "1.0.0-preview.17",
     "tslib": "^2.3.1"
   },
   "publishConfig": {

--- a/packages/serialization/json/package.json
+++ b/packages/serialization/json/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/microsoft/kiota-typescript#readme",
   "dependencies": {
-    "@microsoft/kiota-abstractions": "1.0.0-preview.16",
+    "@microsoft/kiota-abstractions": "1.0.0-preview.17",
     "tslib": "^2.3.1"
   },
   "publishConfig": {

--- a/packages/serialization/text/package.json
+++ b/packages/serialization/text/package.json
@@ -39,7 +39,7 @@
   },
   "homepage": "https://github.com/microsoft/kiota-typescript#readme",
   "dependencies": {
-    "@microsoft/kiota-abstractions": "1.0.0-preview.16",
+    "@microsoft/kiota-abstractions": "1.0.0-preview.17",
     "tslib": "^2.3.1"
   },
   "publishConfig": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -9,9 +9,9 @@
   },
   "dependencies": {
     "@azure/identity": "^3.0.0",
-    "@microsoft/kiota-abstractions": "1.0.0-preview.16",
+    "@microsoft/kiota-abstractions": "1.0.0-preview.17",
     "@microsoft/kiota-authentication-azure": "1.0.0-preview.12",
-    "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.15",
+    "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.16",
     "@microsoft/kiota-serialization-form": "1.0.0-preview.6",
     "@microsoft/kiota-serialization-json": "1.0.0-preview.15",
     "@microsoft/kiota-serialization-text": "1.0.0-preview.14"


### PR DESCRIPTION
Related to https://github.com/microsoft/kiota/issues/2524
Also closes https://github.com/microsoft/kiota/issues/2241

Case insensitivity of headers is deferred in this PR as the typescript implementation does not cater for this. Furthermore, it's not too clear on when the implementation changed from Map to Record for holding the headers. 

Created https://github.com/microsoft/kiota-typescript/issues/618 to track this