### PR TITLE
disable secrets usage on forks

### DIFF
--- a/.github/workflows/generate_graph_test.yml
+++ b/.github/workflows/generate_graph_test.yml
@@ -86,7 +86,7 @@ jobs:
             echo $PKG_DATA
         - name: Comment PR Bundle Size
           uses: thollander/actions-comment-pull-request@v2
-          if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+          if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'microsoft' }}
           with:
             message: |
               Generated ${{ env.PKG_NAME }} SDK package:
@@ -113,7 +113,7 @@ jobs:
             echo $APP_DATA
         - name: Comment PR Sample App Size
           uses: thollander/actions-comment-pull-request@v2
-          if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+          if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner.login == 'microsoft' }}
           with:
             message: |
               Generated sample app bundle:


### PR DESCRIPTION
Fix #667 

GH Secrets cannot be used from forks and on PRs, in this way the comment is going to be displayed on PRs from branches IN this repository but the check will be skipped on forks.

Probably having a separate workflow for this purpose would be the best, but this is the minimal change to get the job done for me as an external contributor.