### PR TITLE
Fix uri-template-lite binding

### DIFF
--- a/packages/abstractions/src/requestInformation.ts
+++ b/packages/abstractions/src/requestInformation.ts
@@ -39,7 +39,6 @@ export class RequestInformation {
     } else if (!this.urlTemplate) {
       throw new Error("urlTemplate cannot be undefined");
     } else {
-      const template = new (Template as any)(this.urlTemplate);
       const data = {} as { [key: string]: unknown };
       for (const key in this.queryParameters) {
         if (this.queryParameters[key]) {
@@ -51,7 +50,7 @@ export class RequestInformation {
           data[key] = this.pathParameters[key];
         }
       }
-      return template.expand(data);
+      return Template.expand(this.urlTemplate, data);
     }
   }
   /** Sets the URL of the request */

--- a/packages/abstractions/types/uri-template-lite/index.d.ts
+++ b/packages/abstractions/types/uri-template-lite/index.d.ts
@@ -1,5 +1,3 @@
 declare module 'uri-template-lite' {
-  class Template {
-    constructor(template: string);
-  }
+  function expand(template: string, data: { [key: string]: unknown }): string;
 }


### PR DESCRIPTION
Fix for this comment:
https://github.com/microsoft/kiota-typescript/pull/619#issuecomment-1596171382
I manually tested it with a Vanilla fresh vite build and now it works as expected.

cc. @ksdaniel would you be able to confirm?
