### PR TITLE
ensure window isn't null when running in non-browser environment.

### DIFF
--- a/packages/abstractions/src/authentication/validateProtocol.ts
+++ b/packages/abstractions/src/authentication/validateProtocol.ts
@@ -5,5 +5,5 @@ export function validateProtocol(url: string): void {
 }
 function windowUrlStartsWithHttps(): boolean {
     // @ts-ignore
-    return window && window.location && (window.location.protocol as string).toLowerCase() !== 'https:';
+    return typeof window !== 'undefined' && typeof window.location !== 'undefined' && (window.location.protocol as string).toLowerCase() !== 'https:';
 }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/kiota-typescript/issues/394