### PR TITLE
- bumps node version

### DIFF
--- a/.github/workflows/build_test_validate.yml
+++ b/.github/workflows/build_test_validate.yml
@@ -15,7 +15,7 @@ jobs:
           TENANT_ID: ${{ secrets.TENANT_ID }}
         strategy:
           matrix:
-            node-version: [14.x, 16.x, 18.x]
+            node-version: [16.x, 18.x, 20x]
         steps:
         - uses: actions/checkout@v3
         - name: Use Node.js ${{ matrix.node-version }}
@@ -58,7 +58,7 @@ jobs:
           - uses: actions/checkout@v3
           - uses: actions/setup-node@v3
             with:
-              node-version: 16
+              node-version: 18
               registry-url: https://registry.npmjs.org/
           - run: |
               git config --global user.name '${GITHUB_ACTOR}'

--- a/.github/workflows/generate_graph_test.yml
+++ b/.github/workflows/generate_graph_test.yml
@@ -35,7 +35,7 @@ jobs:
           NODE_OPTIONS: "--max_old_space_size=9182"
         strategy:
           matrix:
-            node-version: [18.x]
+            node-version: [20.x]
         steps:
         - uses: actions/checkout@v3
         - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
14 is out of support, 20 is current, aligning https://nodejs.dev/en/about/releases/