### PR TITLE
- removes node 14 as it's out of support now

### DIFF
--- a/.github/workflows/build_test_validate.yml
+++ b/.github/workflows/build_test_validate.yml
@@ -15,7 +15,7 @@ jobs:
           TENANT_ID: ${{ secrets.TENANT_ID }}
         strategy:
           matrix:
-            node-version: [14.x, 16.x, 18.x]
+            node-version: [16.x, 18.x]
         steps:
         - uses: actions/checkout@v3
         - name: Use Node.js ${{ matrix.node-version }}
@@ -58,7 +58,7 @@ jobs:
           - uses: actions/checkout@v3
           - uses: actions/setup-node@v3
             with:
-              node-version: 16
+              node-version: 18
               registry-url: https://registry.npmjs.org/
           - run: |
               git config --global user.name '${GITHUB_ACTOR}'


### PR DESCRIPTION
14 is out of support, aligning https://nodejs.dev/en/about/releases/