### PR TITLE
Update the abstraction library code to use import type for interfaces

### DIFF
--- a/packages/abstractions/src/apiClientBuilder.ts
+++ b/packages/abstractions/src/apiClientBuilder.ts
@@ -1,8 +1,10 @@
 import {
-  ParseNodeFactory,
   ParseNodeFactoryRegistry,
-  SerializationWriterFactory,
   SerializationWriterFactoryRegistry,
+} from "./serialization";
+import type {
+  ParseNodeFactory,
+  SerializationWriterFactory
 } from "./serialization";
 import {
   BackingStoreParseNodeFactory,

--- a/packages/abstractions/src/authentication/anonymousAuthenticationProvider.ts
+++ b/packages/abstractions/src/authentication/anonymousAuthenticationProvider.ts
@@ -1,5 +1,5 @@
 import { RequestInformation } from "../requestInformation";
-import { AuthenticationProvider } from "./authenticationProvider";
+import type { AuthenticationProvider } from "./authenticationProvider";
 
 /** This authentication provider does not perform any authentication.   */
 export class AnonymousAuthenticationProvider implements AuthenticationProvider {

--- a/packages/abstractions/src/authentication/apiKeyAuthenticationProvider.ts
+++ b/packages/abstractions/src/authentication/apiKeyAuthenticationProvider.ts
@@ -1,6 +1,6 @@
 import { RequestInformation } from "../requestInformation";
 import { AllowedHostsValidator } from "./allowedHostsValidator";
-import { AuthenticationProvider } from "./authenticationProvider";
+import type { AuthenticationProvider } from "./authenticationProvider";
 import { validateProtocol } from "./validateProtocol";
 
 /** Authenticate a request by using an API Key */

--- a/packages/abstractions/src/authentication/baseBearerTokenAuthenticationProvider.ts
+++ b/packages/abstractions/src/authentication/baseBearerTokenAuthenticationProvider.ts
@@ -1,6 +1,6 @@
 import { RequestInformation } from "../requestInformation";
-import { AccessTokenProvider } from "./accessTokenProvider";
-import { AuthenticationProvider } from "./authenticationProvider";
+import type { AccessTokenProvider } from "./accessTokenProvider";
+import type { AuthenticationProvider } from "./authenticationProvider";
 
 /** Provides a base class for implementing AuthenticationProvider for Bearer token scheme. */
 export class BaseBearerTokenAuthenticationProvider

--- a/packages/abstractions/src/baseRequestBuilder.ts
+++ b/packages/abstractions/src/baseRequestBuilder.ts
@@ -1,5 +1,5 @@
 import { getPathParameters } from "./getPathParameters";
-import { RequestAdapter } from "./requestAdapter";
+import type { RequestAdapter } from "./requestAdapter";
 
 export abstract class BaseRequestBuilder {
   /** Path parameters for the request */

--- a/packages/abstractions/src/multipartBody.ts
+++ b/packages/abstractions/src/multipartBody.ts
@@ -3,10 +3,8 @@ import { Guid } from "guid-typescript";
 import type { RequestAdapter } from "./requestAdapter";
 import type {
   ModelSerializerFunction,
-  ParseNode,
-  SerializationWriter,
 } from "./serialization";
-import type { Parsable } from "./serialization/parsable";
+import type { Parsable, ParseNode, SerializationWriter } from "./serialization";
 /**
  * Defines an interface for a multipart body for request or response.
  */

--- a/packages/abstractions/src/nativeResponseHandler.ts
+++ b/packages/abstractions/src/nativeResponseHandler.ts
@@ -1,5 +1,6 @@
-import { ResponseHandler } from "./responseHandler";
-import { Parsable, ParsableFactory } from "./serialization";
+import type { ResponseHandler } from "./responseHandler";
+import { ParsableFactory } from "./serialization";
+import type { Parsable } from "./serialization";
 
 /** Default response handler to access the native response object. */
 export class NativeResponseHandler implements ResponseHandler {

--- a/packages/abstractions/src/nativeResponseWrapper.ts
+++ b/packages/abstractions/src/nativeResponseWrapper.ts
@@ -1,6 +1,6 @@
 import { NativeResponseHandler } from "./nativeResponseHandler";
 import { RequestOption } from "./requestOption";
-import { ResponseHandler } from "./responseHandler";
+import type { ResponseHandler } from "./responseHandler";
 
 type originalCallType<modelType, queryParametersType, headersType> = (
   q?: queryParametersType,

--- a/packages/abstractions/src/requestAdapter.ts
+++ b/packages/abstractions/src/requestAdapter.ts
@@ -1,10 +1,7 @@
 import { RequestInformation } from "./requestInformation";
-import {
-  Parsable,
-  ParsableFactory,
-  SerializationWriterFactory,
-} from "./serialization";
-import { BackingStoreFactory } from "./store";
+import { ParsableFactory } from "./serialization";
+import type { Parsable, SerializationWriterFactory } from "./serialization";
+import type { BackingStoreFactory } from "./store";
 
 /** Service responsible for translating abstract Request Info into concrete native HTTP requests. */
 export interface RequestAdapter {

--- a/packages/abstractions/src/requestInformation.ts
+++ b/packages/abstractions/src/requestInformation.ts
@@ -6,13 +6,12 @@ import { Duration } from "./duration";
 import { HttpMethod } from "./httpMethod";
 import { MultipartBody } from "./multipartBody";
 import { createRecordWithCaseInsensitiveKeys } from "./recordWithCaseInsensitiveKeys";
-import { RequestAdapter } from "./requestAdapter";
-import { RequestOption } from "./requestOption";
+import type { RequestAdapter } from "./requestAdapter";
+import type { RequestOption } from "./requestOption";
 import {
   ModelSerializerFunction,
-  Parsable,
-  SerializationWriter,
 } from "./serialization";
+import type { Parsable, SerializationWriter } from "./serialization";
 import { TimeOnly } from "./timeOnly";
 
 /** This class represents an abstract HTTP request. */

--- a/packages/abstractions/src/responseHandler.ts
+++ b/packages/abstractions/src/responseHandler.ts
@@ -1,4 +1,5 @@
-import { Parsable, ParsableFactory } from "./serialization";
+import { ParsableFactory } from "./serialization";
+import type { Parsable } from "./serialization";
 
 /** Defines the contract for a response handler. */
 export interface ResponseHandler {

--- a/packages/abstractions/src/responseHandlerOptions.ts
+++ b/packages/abstractions/src/responseHandlerOptions.ts
@@ -5,8 +5,8 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { RequestOption } from "./requestOption";
-import { ResponseHandler } from "./responseHandler";
+import type { RequestOption } from "./requestOption";
+import type { ResponseHandler } from "./responseHandler";
 
 export const ResponseHandlerOptionKey = "ResponseHandlerOptionKey";
 

--- a/packages/abstractions/src/serialization/parsableFactory.ts
+++ b/packages/abstractions/src/serialization/parsableFactory.ts
@@ -1,5 +1,5 @@
-import { Parsable } from "./parsable";
-import { ParseNode } from "./parseNode";
+import type { Parsable } from "./parsable";
+import type { ParseNode } from "./parseNode";
 import { DeserializeIntoModelFunction } from "./serializationFunctionTypes";
 
 /**

--- a/packages/abstractions/src/serialization/parseNode.ts
+++ b/packages/abstractions/src/serialization/parseNode.ts
@@ -3,7 +3,7 @@ import { Guid } from "guid-typescript";
 import { DateOnly } from "../dateOnly";
 import { Duration } from "../duration";
 import { TimeOnly } from "../timeOnly";
-import { Parsable } from "./parsable";
+import type { Parsable } from "./parsable";
 import { ParsableFactory } from "./parsableFactory";
 
 /**

--- a/packages/abstractions/src/serialization/parseNodeFactory.ts
+++ b/packages/abstractions/src/serialization/parseNodeFactory.ts
@@ -1,4 +1,4 @@
-import { ParseNode } from "./parseNode";
+import type { ParseNode } from "./parseNode";
 
 /**
  * Defines the contract for a factory that is used to create {@link ParseNode}s.

--- a/packages/abstractions/src/serialization/parseNodeFactoryRegistry.ts
+++ b/packages/abstractions/src/serialization/parseNodeFactoryRegistry.ts
@@ -1,5 +1,5 @@
-import { ParseNode } from "./parseNode";
-import { ParseNodeFactory } from "./parseNodeFactory";
+import type { ParseNode } from "./parseNode";
+import type { ParseNodeFactory } from "./parseNodeFactory";
 
 /**
  * This factory holds a list of all the registered factories for the various types of nodes.

--- a/packages/abstractions/src/serialization/parseNodeProxyFactory.ts
+++ b/packages/abstractions/src/serialization/parseNodeProxyFactory.ts
@@ -1,6 +1,6 @@
-import { Parsable } from "./parsable";
-import { ParseNode } from "./parseNode";
-import { ParseNodeFactory } from "./parseNodeFactory";
+import type { Parsable } from "./parsable";
+import type { ParseNode } from "./parseNode";
+import type { ParseNodeFactory } from "./parseNodeFactory";
 
 /** Proxy factory that allows the composition of before and after callbacks on existing factories. */
 export abstract class ParseNodeProxyFactory implements ParseNodeFactory {

--- a/packages/abstractions/src/serialization/serializationFunctionTypes.ts
+++ b/packages/abstractions/src/serialization/serializationFunctionTypes.ts
@@ -1,6 +1,6 @@
-import { Parsable } from "./parsable";
-import { ParseNode } from "./parseNode";
-import { SerializationWriter } from "./serializationWriter";
+import type { Parsable } from "./parsable";
+import type { ParseNode } from "./parseNode";
+import type { SerializationWriter } from "./serializationWriter";
 
 export type ModelSerializerFunction<T extends Parsable> = (
   writer: SerializationWriter,

--- a/packages/abstractions/src/serialization/serializationWriter.ts
+++ b/packages/abstractions/src/serialization/serializationWriter.ts
@@ -3,7 +3,7 @@ import { Guid } from "guid-typescript";
 import { DateOnly } from "../dateOnly";
 import { Duration } from "../duration";
 import { TimeOnly } from "../timeOnly";
-import { Parsable } from "./parsable";
+import type { Parsable } from "./parsable";
 import { ModelSerializerFunction } from "./serializationFunctionTypes";
 
 /** Defines an interface for serialization of objects to a stream. */

--- a/packages/abstractions/src/serialization/serializationWriterFactory.ts
+++ b/packages/abstractions/src/serialization/serializationWriterFactory.ts
@@ -1,4 +1,4 @@
-import { SerializationWriter } from "./serializationWriter";
+import type { SerializationWriter } from "./serializationWriter";
 
 /** Defines the contract for a factory that creates SerializationWriter instances. */
 export interface SerializationWriterFactory {

--- a/packages/abstractions/src/serialization/serializationWriterFactoryRegistry.ts
+++ b/packages/abstractions/src/serialization/serializationWriterFactoryRegistry.ts
@@ -1,5 +1,5 @@
-import { SerializationWriter } from "./serializationWriter";
-import { SerializationWriterFactory } from "./serializationWriterFactory";
+import type { SerializationWriter } from "./serializationWriter";
+import type { SerializationWriterFactory } from "./serializationWriterFactory";
 
 /** This factory holds a list of all the registered factories for the various types of nodes. */
 export class SerializationWriterFactoryRegistry

--- a/packages/abstractions/src/serialization/serializationWriterProxyFactory.ts
+++ b/packages/abstractions/src/serialization/serializationWriterProxyFactory.ts
@@ -1,6 +1,6 @@
-import { Parsable } from "./parsable";
-import { SerializationWriter } from "./serializationWriter";
-import { SerializationWriterFactory } from "./serializationWriterFactory";
+import type { Parsable } from "./parsable";
+import type { SerializationWriter } from "./serializationWriter";
+import type { SerializationWriterFactory } from "./serializationWriterFactory";
 
 /** Proxy factory that allows the composition of before and after callbacks on existing factories. */
 export abstract class SerializationWriterProxyFactory

--- a/packages/abstractions/src/store/backingStoreFactory.ts
+++ b/packages/abstractions/src/store/backingStoreFactory.ts
@@ -1,4 +1,4 @@
-import { BackingStore } from "./backingStore";
+import type { BackingStore } from "./backingStore";
 
 /** Defines the contract for a factory that creates backing stores. */
 export interface BackingStoreFactory {

--- a/packages/abstractions/src/store/backingStoreFactorySingleton.ts
+++ b/packages/abstractions/src/store/backingStoreFactorySingleton.ts
@@ -1,4 +1,4 @@
-import { BackingStoreFactory } from "./backingStoreFactory";
+import type { BackingStoreFactory } from "./backingStoreFactory";
 import { InMemoryBackingStoreFactory } from "./inMemoryBackingStoreFactory";
 
 export class BackingStoreFactorySingleton {

--- a/packages/abstractions/src/store/backingStoreParseNodeFactory.ts
+++ b/packages/abstractions/src/store/backingStoreParseNodeFactory.ts
@@ -1,5 +1,6 @@
-import { ParseNodeFactory, ParseNodeProxyFactory } from "../serialization";
-import { BackedModel } from "./backedModel";
+import { ParseNodeProxyFactory } from "../serialization";
+import type { ParseNodeFactory } from "../serialization";
+import type { BackedModel } from "./backedModel";
 
 /** Proxy implementation of ParseNodeFactory for the backing store that automatically sets the state of the backing store when deserializing. */
 export class BackingStoreParseNodeFactory extends ParseNodeProxyFactory {

--- a/packages/abstractions/src/store/backingStoreSerializationWriterProxyFactory.ts
+++ b/packages/abstractions/src/store/backingStoreSerializationWriterProxyFactory.ts
@@ -1,8 +1,6 @@
-import {
-  SerializationWriterFactory,
-  SerializationWriterProxyFactory,
-} from "../serialization";
-import { BackedModel } from "./backedModel";
+import { SerializationWriterProxyFactory } from "../serialization";
+import type { SerializationWriterFactory } from "../serialization";
+import type { BackedModel } from "./backedModel";
 
 /**Proxy implementation of SerializationWriterFactory for the backing store that automatically sets the state of the backing store when serializing. */
 export class BackingStoreSerializationWriterProxyFactory extends SerializationWriterProxyFactory {

--- a/packages/abstractions/src/store/inMemoryBackingStore.ts
+++ b/packages/abstractions/src/store/inMemoryBackingStore.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from "uuid";
 
-import { BackingStore } from "./backingStore";
+import type { BackingStore } from "./backingStore";
 
 interface storeEntryWrapper {
   changed: boolean;

--- a/packages/abstractions/src/store/inMemoryBackingStoreFactory.ts
+++ b/packages/abstractions/src/store/inMemoryBackingStoreFactory.ts
@@ -1,5 +1,5 @@
-import { BackingStore } from "./backingStore";
-import { BackingStoreFactory } from "./backingStoreFactory";
+import type { BackingStore } from "./backingStore";
+import type { BackingStoreFactory } from "./backingStoreFactory";
 import { InMemoryBackingStore } from "./inMemoryBackingStore";
 
 /** This class is used to create instances of InMemoryBackingStore */

--- a/packages/abstractions/test/common/multipartBody.ts
+++ b/packages/abstractions/test/common/multipartBody.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 
 import { MultipartBody, serializeMultipartBody } from "../../src/multipartBody";
-import { SerializationWriter } from "../../src/serialization";
+import type { SerializationWriter } from "../../src/serialization";
 describe("multipartBody", () => {
   it("implements defensive programming", () => {
     const mpBody = new MultipartBody();

--- a/packages/abstractions/test/common/requestInformation.ts
+++ b/packages/abstractions/test/common/requestInformation.ts
@@ -12,11 +12,13 @@ const assert = chai.assert;
 
 import {
   HttpMethod,
-  Parsable,
+  RequestInformation
+} from "../../src";
+import type { 
   RequestAdapter,
-  RequestInformation,
+  Parsable,
   SerializationWriter,
-  SerializationWriterFactory,
+  SerializationWriterFactory
 } from "../../src";
 import { MultipartBody } from "../../src/multipartBody";
 

--- a/packages/authentication/azure/src/azureIdentityAccessTokenProvider.ts
+++ b/packages/authentication/azure/src/azureIdentityAccessTokenProvider.ts
@@ -1,15 +1,13 @@
 import { GetTokenOptions, TokenCredential } from "@azure/core-auth";
 import {
-  AccessTokenProvider,
   AllowedHostsValidator,
   validateProtocol,
 } from "@microsoft/kiota-abstractions";
+import type { AccessTokenProvider } from "@microsoft/kiota-abstractions";
 import { Span, trace } from "@opentelemetry/api";
 
-import {
-  ObservabilityOptions,
-  ObservabilityOptionsImpl,
-} from "./observabilityOptions";
+import { ObservabilityOptionsImpl } from "./observabilityOptions";
+import type { ObservabilityOptions } from "./observabilityOptions";
 
 /** Access token provider that leverages the Azure Identity library to retrieve an access token. */
 export class AzureIdentityAccessTokenProvider implements AccessTokenProvider {

--- a/packages/authentication/azure/src/azureIdentityAuthenticationProvider.ts
+++ b/packages/authentication/azure/src/azureIdentityAuthenticationProvider.ts
@@ -2,10 +2,8 @@ import { GetTokenOptions, TokenCredential } from "@azure/core-auth";
 import { BaseBearerTokenAuthenticationProvider } from "@microsoft/kiota-abstractions";
 
 import { AzureIdentityAccessTokenProvider } from "./azureIdentityAccessTokenProvider";
-import {
-  ObservabilityOptions,
-  ObservabilityOptionsImpl,
-} from "./observabilityOptions";
+import { ObservabilityOptionsImpl } from "./observabilityOptions";
+import type { ObservabilityOptions } from "./observabilityOptions";
 
 export class AzureIdentityAuthenticationProvider extends BaseBearerTokenAuthenticationProvider {
   /**

--- a/packages/authentication/spfx/src/azureAdSpfxAccessTokenProvider.ts
+++ b/packages/authentication/spfx/src/azureAdSpfxAccessTokenProvider.ts
@@ -1,15 +1,13 @@
 import {
-  AccessTokenProvider,
   AllowedHostsValidator,
   validateProtocol,
 } from "@microsoft/kiota-abstractions";
+import type { AccessTokenProvider } from "@microsoft/kiota-abstractions";
 import { AadTokenProvider } from "@microsoft/sp-http";
 import { Span, trace } from "@opentelemetry/api";
 
-import {
-  ObservabilityOptions,
-  ObservabilityOptionsImpl,
-} from "./observabilityOptions";
+import { ObservabilityOptionsImpl } from "./observabilityOptions";
+import type { ObservabilityOptions } from "./observabilityOptions";
 
 export class AzureAdSpfxAccessTokenProvider implements AccessTokenProvider {
   private readonly allowedHostsValidator: AllowedHostsValidator;

--- a/packages/authentication/spfx/src/azureAdSpfxAuthenticationProvider.ts
+++ b/packages/authentication/spfx/src/azureAdSpfxAuthenticationProvider.ts
@@ -1,7 +1,8 @@
 import { BaseBearerTokenAuthenticationProvider } from "@microsoft/kiota-abstractions";
 import { AadTokenProvider } from "@microsoft/sp-http";
 import { AzureAdSpfxAccessTokenProvider } from "./azureAdSpfxAccessTokenProvider";
-import { ObservabilityOptions, ObservabilityOptionsImpl } from "./observabilityOptions";
+import { ObservabilityOptionsImpl } from "./observabilityOptions";
+import type { ObservabilityOptions } from "./observabilityOptions";
 
 export class AzureAdSpfxAuthenticationProvider extends BaseBearerTokenAuthenticationProvider {
   /**

--- a/packages/http/fetch/src/fetchRequestAdapter.ts
+++ b/packages/http/fetch/src/fetchRequestAdapter.ts
@@ -1,8 +1,11 @@
-import { ApiError, AuthenticationProvider, BackingStoreFactory, BackingStoreFactorySingleton, DateOnly, DefaultApiError, Duration, enableBackingStoreForParseNodeFactory, enableBackingStoreForSerializationWriterFactory, Parsable, ParsableFactory, ParseNode, ParseNodeFactory, ParseNodeFactoryRegistry, RequestAdapter, RequestInformation, ResponseHandler, ResponseHandlerOption, ResponseHandlerOptionKey, SerializationWriterFactory, SerializationWriterFactoryRegistry, TimeOnly } from "@microsoft/kiota-abstractions";
+import { BackingStoreFactorySingleton, DateOnly, DefaultApiError, Duration, enableBackingStoreForParseNodeFactory, enableBackingStoreForSerializationWriterFactory, ParsableFactory, ParseNodeFactoryRegistry, RequestInformation, ResponseHandlerOption, ResponseHandlerOptionKey, SerializationWriterFactoryRegistry, TimeOnly } from "@microsoft/kiota-abstractions";
+import type { AuthenticationProvider, BackingStoreFactory, Parsable, ParseNode, ParseNodeFactory, SerializationWriterFactory } from "@microsoft/kiota-abstractions";
+import type { ApiError, RequestAdapter, ResponseHandler } from "@microsoft/kiota-abstractions";
 import { Span, SpanStatusCode, trace } from "@opentelemetry/api";
 
 import { HttpClient } from "./httpClient";
-import { ObservabilityOptions, ObservabilityOptionsImpl } from "./observabilityOptions";
+import { ObservabilityOptionsImpl } from "./observabilityOptions";
+import type { ObservabilityOptions } from "./observabilityOptions";
 
 export class FetchRequestAdapter implements RequestAdapter {
 	/** The base url for every request. */

--- a/packages/http/fetch/src/httpClient.ts
+++ b/packages/http/fetch/src/httpClient.ts
@@ -5,10 +5,10 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { RequestOption } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 
 import { CustomFetchHandler } from "./middlewares/customFetchHandler";
-import { Middleware } from "./middlewares/middleware";
+import type { Middleware } from "./middlewares/middleware";
 import { MiddlewareFactory } from "./middlewares/middlewareFactory";
 
 export class HttpClient {

--- a/packages/http/fetch/src/kiotaClientFactory.ts
+++ b/packages/http/fetch/src/kiotaClientFactory.ts
@@ -1,4 +1,4 @@
-import { Middleware } from "./middlewares/middleware";
+import type { Middleware } from "./middlewares/middleware";
 import { MiddlewareFactory } from "./middlewares/middlewareFactory";
 
 /**

--- a/packages/http/fetch/src/middlewares/browser/middlewareFactory.ts
+++ b/packages/http/fetch/src/middlewares/browser/middlewareFactory.ts
@@ -10,7 +10,7 @@
  */
 
 import { CustomFetchHandler } from "../customFetchHandler";
-import { Middleware } from "../middleware";
+import type { Middleware } from "../middleware";
 import { ParametersNameDecodingHandler } from "../parametersNameDecodingHandler";
 import { RetryHandler } from "../retryHandler";
 import { UserAgentHandler } from "../userAgentHandler";

--- a/packages/http/fetch/src/middlewares/chaosHandler.ts
+++ b/packages/http/fetch/src/middlewares/chaosHandler.ts
@@ -9,14 +9,15 @@
  * @module ChaosHandler
  */
 
-import { HttpMethod, RequestOption } from "@microsoft/kiota-abstractions";
+import { HttpMethod } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 import { Span, trace } from "@opentelemetry/api";
 
 import { getObservabilityOptionsFromRequest } from "../observabilityOptions";
 import { FetchHeaders, FetchRequestInit } from "../utils/fetchDefinitions";
-import { Middleware } from "./middleware";
+import type { Middleware } from "./middleware";
 import { httpStatusCode, methodStatusCode } from "./options/ChaosHandlerData";
-import { ChaosHandlerOptions } from "./options/chaosHandlerOptions";
+import type { ChaosHandlerOptions } from "./options/chaosHandlerOptions";
 import { ChaosStrategy } from "./options/chaosStrategy";
 
 /**

--- a/packages/http/fetch/src/middlewares/customFetchHandler.ts
+++ b/packages/http/fetch/src/middlewares/customFetchHandler.ts
@@ -9,7 +9,7 @@
  * @module FetchHandler
  */
 
-import { Middleware } from "./middleware";
+import type { Middleware } from "./middleware";
 
 /**
  * @class

--- a/packages/http/fetch/src/middlewares/middleware.ts
+++ b/packages/http/fetch/src/middlewares/middleware.ts
@@ -4,7 +4,7 @@
  * See License in the project root for license information.
  * -------------------------------------------------------------------------------------------
  */
-import {RequestOption} from "@microsoft/kiota-abstractions";
+import type {RequestOption} from "@microsoft/kiota-abstractions";
 // use import types
 /** Defines the contract for a middleware in the request execution pipeline. */
 export interface Middleware {

--- a/packages/http/fetch/src/middlewares/middlewareFactory.ts
+++ b/packages/http/fetch/src/middlewares/middlewareFactory.ts
@@ -11,7 +11,7 @@
 import fetch from "node-fetch";
 
 import { CustomFetchHandler } from "./customFetchHandler";
-import { Middleware } from "./middleware";
+import type { Middleware } from "./middleware";
 import { ParametersNameDecodingHandler } from "./parametersNameDecodingHandler";
 import { RedirectHandler } from "./redirectHandler";
 import { RetryHandler } from "./retryHandler";

--- a/packages/http/fetch/src/middlewares/options/chaosHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/chaosHandlerOptions.ts
@@ -15,9 +15,9 @@ import { ChaosStrategy } from "./chaosStrategy";
 export const ChaosHandlerOptionsKey = "ChaosHandlerOptionsKey";
 
 /**
- * Class representing ChaosHandlerOptions
- * @class
- * Class
+ * interface representing ChaosHandlerOptions
+ * @interface
+ * interface
  * @implements MiddlewareOptions
  */
 export interface ChaosHandlerOptions {

--- a/packages/http/fetch/src/middlewares/options/parametersNameDecodingOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/parametersNameDecodingOptions.ts
@@ -9,7 +9,7 @@
  * @module ParametersNameDecodingHandlerOptions
  */
 
-import { RequestOption } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 
 export const ParametersNameDecodingHandlerOptionsKey = "RetryHandlerOptionKey";
 

--- a/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
@@ -9,7 +9,7 @@
  * @module RedirectHandlerOptions
  */
 
-import { RequestOption } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 
 /**
  * @type

--- a/packages/http/fetch/src/middlewares/options/retryHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/retryHandlerOptions.ts
@@ -9,7 +9,7 @@
  * @module RetryHandlerOptions
  */
 
-import { RequestOption } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 
 import { FetchResponse } from "../../utils/fetchDefinitions";
 

--- a/packages/http/fetch/src/middlewares/options/telemetryHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/telemetryHandlerOptions.ts
@@ -4,7 +4,7 @@
  * See License in the project root for license information.
  * -------------------------------------------------------------------------------------------
  */
-import { RequestOption } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 
 export interface TelemetryHandlerOptions extends RequestOption {
 	telemetryConfigurator: (url: string, requestInit: RequestInit, requestOptions?: Record<string, RequestOption>, telemetryInfomation?: unknown) => void;

--- a/packages/http/fetch/src/middlewares/options/userAgentHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/userAgentHandlerOptions.ts
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { RequestOption } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 
 import { libraryVersion } from "./version";
 

--- a/packages/http/fetch/src/middlewares/parametersNameDecodingHandler.ts
+++ b/packages/http/fetch/src/middlewares/parametersNameDecodingHandler.ts
@@ -5,11 +5,11 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { RequestOption } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 import { trace } from "@opentelemetry/api";
 
 import { getObservabilityOptionsFromRequest } from "../observabilityOptions";
-import { Middleware } from "./middleware";
+import type { Middleware } from "./middleware";
 import { ParametersNameDecodingHandlerOptions, ParametersNameDecodingHandlerOptionsKey } from "./options/parametersNameDecodingOptions";
 
 /**

--- a/packages/http/fetch/src/middlewares/redirectHandler.ts
+++ b/packages/http/fetch/src/middlewares/redirectHandler.ts
@@ -9,12 +9,13 @@
  * @module RedirectHandler
  */
 
-import { HttpMethod, RequestOption } from "@microsoft/kiota-abstractions";
+import { HttpMethod } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 import { trace } from "@opentelemetry/api";
 
 import { getObservabilityOptionsFromRequest } from "../observabilityOptions";
 import { FetchRequestInit, FetchResponse } from "../utils/fetchDefinitions";
-import { Middleware } from "./middleware";
+import type { Middleware } from "./middleware";
 import { RedirectHandlerOptionKey, RedirectHandlerOptions } from "./options/redirectHandlerOptions";
 
 /**

--- a/packages/http/fetch/src/middlewares/retryHandler.ts
+++ b/packages/http/fetch/src/middlewares/retryHandler.ts
@@ -9,13 +9,14 @@
  * @module RetryHandler
  */
 
-import { HttpMethod, RequestOption } from "@microsoft/kiota-abstractions";
+import { HttpMethod } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 import { trace } from "@opentelemetry/api";
 
 import { getObservabilityOptionsFromRequest } from "../observabilityOptions";
 import { FetchRequestInit, FetchResponse } from "../utils/fetchDefinitions";
 import { getRequestHeader, setRequestHeader } from "../utils/headersUtil";
-import { Middleware } from "./middleware";
+import type { Middleware } from "./middleware";
 import { RetryHandlerOptionKey, RetryHandlerOptions } from "./options/retryHandlerOptions";
 
 /**

--- a/packages/http/fetch/src/middlewares/telemetryHandler.ts
+++ b/packages/http/fetch/src/middlewares/telemetryHandler.ts
@@ -4,10 +4,10 @@
  * See License in the project root for license information.
  * -------------------------------------------------------------------------------------------
  */
-import { RequestOption } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 
-import { Middleware } from "./middleware";
-import { TelemetryHandlerOptions } from "./options/telemetryHandlerOptions";
+import type { Middleware } from "./middleware";
+import type { TelemetryHandlerOptions } from "./options/telemetryHandlerOptions";
 
 export const TelemetryHandlerOptionsKey = "TelemetryHandlerOptionsKey";
 export class TelemetryHandler implements Middleware {

--- a/packages/http/fetch/src/middlewares/userAgentHandler.ts
+++ b/packages/http/fetch/src/middlewares/userAgentHandler.ts
@@ -9,13 +9,13 @@
  * @module UserAgentHandler
  */
 
-import { RequestOption } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 import { trace } from "@opentelemetry/api";
 
 import { getObservabilityOptionsFromRequest } from "../observabilityOptions";
 import { FetchRequestInit } from "../utils/fetchDefinitions";
 import { appendRequestHeader, getRequestHeader } from "../utils/headersUtil";
-import { Middleware } from "./middleware";
+import type { Middleware } from "./middleware";
 import { UserAgentHandlerOptions, UserAgentHandlerOptionsKey } from "./options/userAgentHandlerOptions";
 
 const USER_AGENT_HEADER_KEY = "User-Agent";

--- a/packages/http/fetch/src/observabilityOptions.ts
+++ b/packages/http/fetch/src/observabilityOptions.ts
@@ -1,4 +1,4 @@
-import { RequestOption } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 
 /** Holds the tracing, metrics and logging configuration for the request adapter */
 export interface ObservabilityOptions {

--- a/packages/http/fetch/test/common/fetchRequestAdapter.ts
+++ b/packages/http/fetch/test/common/fetchRequestAdapter.ts
@@ -5,7 +5,8 @@
  * -------------------------------------------------------------------------------------------
  */
 /* eslint-disable @typescript-eslint/no-unused-vars*/
-import { AnonymousAuthenticationProvider, HttpMethod, RequestInformation, RequestOption } from "@microsoft/kiota-abstractions";
+import { AnonymousAuthenticationProvider, HttpMethod, RequestInformation } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 import { assert } from "chai";
 
 import { FetchRequestAdapter } from "../../src/fetchRequestAdapter";

--- a/packages/http/fetch/test/common/middleware/dummyFetchHandler.ts
+++ b/packages/http/fetch/test/common/middleware/dummyFetchHandler.ts
@@ -9,8 +9,8 @@
  * @module DummyHTTPMessageHandler
  */
 
-import { RequestOption } from "@microsoft/kiota-abstractions";
-import { Middleware } from "../../../src/middlewares/middleware";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
+import type { Middleware } from "../../../src/middlewares/middleware";
 
 /**
  * @class

--- a/packages/http/fetch/test/common/middleware/testCallBackMiddleware.ts
+++ b/packages/http/fetch/test/common/middleware/testCallBackMiddleware.ts
@@ -1,6 +1,6 @@
-import { RequestOption } from "@microsoft/kiota-abstractions";
+import type { RequestOption } from "@microsoft/kiota-abstractions";
 
-import { Middleware } from "../../../src/middlewares/middleware";
+import type { Middleware } from "../../../src/middlewares/middleware";
 import { DummyFetchHandler } from "./dummyFetchHandler";
 import { getResponse } from "../../testUtils";
 

--- a/packages/http/fetch/test/common/mockEntity.ts
+++ b/packages/http/fetch/test/common/mockEntity.ts
@@ -1,4 +1,4 @@
-import { Parsable, ParseNode, SerializationWriter } from "@microsoft/kiota-abstractions";
+import type { Parsable, ParseNode, SerializationWriter } from "@microsoft/kiota-abstractions";
 
 export type MockEntity = Parsable;
 

--- a/packages/http/fetch/test/common/mockParseNodeFactory.ts
+++ b/packages/http/fetch/test/common/mockParseNodeFactory.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { DateOnly, Duration, Parsable, ParsableFactory, ParseNode, ParseNodeFactory, TimeOnly } from "@microsoft/kiota-abstractions";
+import { DateOnly, Duration, ParsableFactory, TimeOnly } from "@microsoft/kiota-abstractions";
+import type { Parsable, ParseNode, ParseNodeFactory } from "@microsoft/kiota-abstractions";
 import { Guid } from "guid-typescript";
 
 export class MockParseNodeFactory implements ParseNodeFactory {

--- a/packages/serialization/form/src/browser/formParseNodeFactory.ts
+++ b/packages/serialization/form/src/browser/formParseNodeFactory.ts
@@ -1,5 +1,4 @@
-import { ParseNode, ParseNodeFactory } from "@microsoft/kiota-abstractions";
-
+import type { ParseNode, ParseNodeFactory } from "@microsoft/kiota-abstractions";
 import { FormParseNode } from "./../formParseNode";
 
 export class FormParseNodeFactory implements ParseNodeFactory {

--- a/packages/serialization/form/src/formParseNode.ts
+++ b/packages/serialization/form/src/formParseNode.ts
@@ -1,13 +1,12 @@
 import {
   DateOnly,
   Duration,
-  Parsable,
   ParsableFactory,
   parseGuidString,
-  ParseNode,
   TimeOnly,
   toFirstCharacterUpper,
 } from "@microsoft/kiota-abstractions";
+import type { Parsable, ParseNode } from "@microsoft/kiota-abstractions";
 
 export class FormParseNode implements ParseNode {
   private readonly _fields: Record<string, string> = {};

--- a/packages/serialization/form/src/formParseNodeFactory.ts
+++ b/packages/serialization/form/src/formParseNodeFactory.ts
@@ -1,4 +1,4 @@
-import { ParseNode, ParseNodeFactory } from "@microsoft/kiota-abstractions";
+import type { ParseNode, ParseNodeFactory} from "@microsoft/kiota-abstractions";
 import { TextDecoder } from "util";
 
 import { FormParseNode } from "./formParseNode";

--- a/packages/serialization/form/src/formSerializationWriter.ts
+++ b/packages/serialization/form/src/formSerializationWriter.ts
@@ -3,10 +3,9 @@ import {
   DateOnly,
   Duration,
   ModelSerializerFunction,
-  Parsable,
-  SerializationWriter,
   TimeOnly,
 } from "@microsoft/kiota-abstractions";
+import type { Parsable, SerializationWriter } from "@microsoft/kiota-abstractions";
 import { Guid } from "guid-typescript";
 
 export class FormSerializationWriter implements SerializationWriter {

--- a/packages/serialization/form/src/formSerializationWriterFactory.ts
+++ b/packages/serialization/form/src/formSerializationWriterFactory.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SerializationWriter,
   SerializationWriterFactory,
 } from "@microsoft/kiota-abstractions";

--- a/packages/serialization/form/test/common/formParseNode.ts
+++ b/packages/serialization/form/test/common/formParseNode.ts
@@ -1,10 +1,8 @@
 import { assert } from "chai";
 
 import { FormParseNode } from "../../src/index";
-import {
-  createTestParserFromDiscriminatorValue,
-  TestEntity,
-} from "../testEntity";
+import { createTestParserFromDiscriminatorValue } from "../testEntity";
+import type { TestEntity } from "../testEntity";
 
 describe("FormParseNode", () => {
   const testUserForm =

--- a/packages/serialization/form/test/common/formSerializationWriter.ts
+++ b/packages/serialization/form/test/common/formSerializationWriter.ts
@@ -2,7 +2,8 @@ import { DateOnly, Duration, TimeOnly } from "@microsoft/kiota-abstractions";
 import { assert } from "chai";
 
 import { FormSerializationWriter } from "../../src";
-import { serializeTestEntity, TestEntity } from "../testEntity";
+import { serializeTestEntity } from "../testEntity";
+import type { TestEntity } from "../testEntity";
 
 describe("FormSerializationWriter", () => {
   it("writesSampleObjectValue", () => {

--- a/packages/serialization/form/test/testEntity.ts
+++ b/packages/serialization/form/test/testEntity.ts
@@ -1,11 +1,13 @@
 import {
-  AdditionalDataHolder,
   DateOnly,
   Duration,
+  TimeOnly,
+} from "@microsoft/kiota-abstractions";
+import type { 
+  AdditionalDataHolder,
   Parsable,
   ParseNode,
-  SerializationWriter,
-  TimeOnly,
+  SerializationWriter
 } from "@microsoft/kiota-abstractions";
 
 export interface TestEntity extends Parsable, AdditionalDataHolder {

--- a/packages/serialization/json/src/browser/jsonParseNodeFactory.ts
+++ b/packages/serialization/json/src/browser/jsonParseNodeFactory.ts
@@ -1,5 +1,4 @@
-import { ParseNode, ParseNodeFactory } from "@microsoft/kiota-abstractions";
-
+import type { ParseNode, ParseNodeFactory } from "@microsoft/kiota-abstractions";
 import { JsonParseNode } from "./../jsonParseNode";
 
 export class JsonParseNodeFactory implements ParseNodeFactory {

--- a/packages/serialization/json/src/jsonParseNode.ts
+++ b/packages/serialization/json/src/jsonParseNode.ts
@@ -1,13 +1,12 @@
 import {
   DateOnly,
   Duration,
-  Parsable,
   ParsableFactory,
   parseGuidString,
-  ParseNode,
   TimeOnly,
   toFirstCharacterUpper,
 } from "@microsoft/kiota-abstractions";
+import type { Parsable, ParseNode } from "@microsoft/kiota-abstractions";
 
 export class JsonParseNode implements ParseNode {
   /**

--- a/packages/serialization/json/src/jsonParseNodeFactory.ts
+++ b/packages/serialization/json/src/jsonParseNodeFactory.ts
@@ -1,4 +1,4 @@
-import { ParseNode, ParseNodeFactory } from "@microsoft/kiota-abstractions";
+import type { ParseNode, ParseNodeFactory } from "@microsoft/kiota-abstractions";
 import { TextDecoder } from "util";
 
 import { JsonParseNode } from "./jsonParseNode";

--- a/packages/serialization/json/src/jsonSerializationWriter.ts
+++ b/packages/serialization/json/src/jsonSerializationWriter.ts
@@ -3,9 +3,11 @@ import {
   DateOnly,
   Duration,
   ModelSerializerFunction,
-  Parsable,
-  SerializationWriter,
   TimeOnly,
+} from "@microsoft/kiota-abstractions";
+import type {
+  Parsable,
+  SerializationWriter
 } from "@microsoft/kiota-abstractions";
 import { Guid } from "guid-typescript";
 

--- a/packages/serialization/json/src/jsonSerializationWriterFactory.ts
+++ b/packages/serialization/json/src/jsonSerializationWriterFactory.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SerializationWriter,
   SerializationWriterFactory,
 } from "@microsoft/kiota-abstractions";

--- a/packages/serialization/json/test/common/JsonParseNode.ts
+++ b/packages/serialization/json/test/common/JsonParseNode.ts
@@ -1,10 +1,8 @@
 import { assert } from "chai";
 
 import { JsonParseNode } from "../../src/index";
-import {
-  createTestParserFromDiscriminatorValue,
-  TestParser,
-} from "./testEntity";
+import { createTestParserFromDiscriminatorValue } from "./testEntity";
+import type { TestParser } from "./testEntity";
 
 describe("JsonParseNode", () => {
   it("jsonParseNode:initializes", async () => {

--- a/packages/serialization/json/test/common/jsonSerializationWriter.ts
+++ b/packages/serialization/json/test/common/jsonSerializationWriter.ts
@@ -4,7 +4,9 @@ import { JsonParseNode, JsonSerializationWriter } from "../../src/index";
 import {
   createTestParserFromDiscriminatorValue,
   serializeTestParser,
-  TestParser,
+} from "./testEntity";
+import type {
+  TestParser
 } from "./testEntity";
 
 describe("JsonParseNode", () => {

--- a/packages/serialization/json/test/common/testEntity.ts
+++ b/packages/serialization/json/test/common/testEntity.ts
@@ -1,5 +1,4 @@
-import { ParseNode, SerializationWriter } from "@microsoft/kiota-abstractions";
-
+import type { ParseNode, SerializationWriter } from "@microsoft/kiota-abstractions";
 export interface TestParser {
   testCollection?: string[] | undefined;
   testString?: string | undefined;

--- a/packages/serialization/multipart/src/multipartSerializationWriter.ts
+++ b/packages/serialization/multipart/src/multipartSerializationWriter.ts
@@ -4,9 +4,11 @@ import {
   Duration,
   ModelSerializerFunction,
   MultipartBody,
-  Parsable,
-  SerializationWriter,
   TimeOnly,
+} from "@microsoft/kiota-abstractions";
+import type {
+  Parsable,
+  SerializationWriter
 } from "@microsoft/kiota-abstractions";
 import { Guid } from "guid-typescript";
 

--- a/packages/serialization/multipart/src/multipartSerializationWriterFactory.ts
+++ b/packages/serialization/multipart/src/multipartSerializationWriterFactory.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SerializationWriter,
   SerializationWriterFactory,
 } from "@microsoft/kiota-abstractions";

--- a/packages/serialization/multipart/test/common/multipartSerializationWriter.ts
+++ b/packages/serialization/multipart/test/common/multipartSerializationWriter.ts
@@ -2,15 +2,16 @@ import {
   DateOnly,
   Duration,
   MultipartBody,
-  RequestAdapter,
   serializeMultipartBody,
   TimeOnly,
 } from "@microsoft/kiota-abstractions";
+import type { RequestAdapter } from "@microsoft/kiota-abstractions";
 import { JsonSerializationWriterFactory } from "@microsoft/kiota-serialization-json";
 import { assert } from "chai";
 
 import { MultipartSerializationWriter } from "../../src";
-import { serializeTestEntity, TestEntity } from "../testEntity";
+import { serializeTestEntity } from "../testEntity";
+import type { TestEntity } from "../testEntity";
 
 describe("MultipartSerializationWriter", () => {
   it("throws on parsable serialization", () => {

--- a/packages/serialization/multipart/test/testEntity.ts
+++ b/packages/serialization/multipart/test/testEntity.ts
@@ -1,11 +1,13 @@
 import {
-  AdditionalDataHolder,
   DateOnly,
   Duration,
+  TimeOnly,
+} from "@microsoft/kiota-abstractions";
+import type { 
+  AdditionalDataHolder,
   Parsable,
   ParseNode,
-  SerializationWriter,
-  TimeOnly,
+  SerializationWriter
 } from "@microsoft/kiota-abstractions";
 
 export interface TestEntity extends Parsable, AdditionalDataHolder {

--- a/packages/serialization/text/src/browser/textParseNodeFactory.ts
+++ b/packages/serialization/text/src/browser/textParseNodeFactory.ts
@@ -1,5 +1,4 @@
-import { ParseNode, ParseNodeFactory } from "@microsoft/kiota-abstractions";
-
+import type { ParseNode, ParseNodeFactory } from "@microsoft/kiota-abstractions";
 import { TextParseNode } from "./../textParseNode";
 
 export class TextParseNodeFactory implements ParseNodeFactory {

--- a/packages/serialization/text/src/textParseNode.ts
+++ b/packages/serialization/text/src/textParseNode.ts
@@ -1,13 +1,12 @@
 import {
   DateOnly,
   Duration,
-  Parsable,
   ParsableFactory,
   parseGuidString,
-  ParseNode,
   TimeOnly,
   toFirstCharacterUpper,
 } from "@microsoft/kiota-abstractions";
+import type { Parsable, ParseNode } from "@microsoft/kiota-abstractions";
 
 export class TextParseNode implements ParseNode {
   private static noStructuredDataMessage =

--- a/packages/serialization/text/src/textParseNodeFactory.ts
+++ b/packages/serialization/text/src/textParseNodeFactory.ts
@@ -1,4 +1,4 @@
-import { ParseNode, ParseNodeFactory } from "@microsoft/kiota-abstractions";
+import type { ParseNode, ParseNodeFactory } from "@microsoft/kiota-abstractions";
 import { TextDecoder } from "util";
 
 import { TextParseNode } from "./textParseNode";

--- a/packages/serialization/text/src/textSerializationWriter.ts
+++ b/packages/serialization/text/src/textSerializationWriter.ts
@@ -3,10 +3,9 @@ import {
   DateOnly,
   Duration,
   ModelSerializerFunction,
-  Parsable,
-  SerializationWriter,
   TimeOnly,
 } from "@microsoft/kiota-abstractions";
+import type { Parsable, SerializationWriter } from "@microsoft/kiota-abstractions";
 import { Guid } from "guid-typescript";
 
 export class TextSerializationWriter implements SerializationWriter {

--- a/packages/serialization/text/src/textSerializationWriterFactory.ts
+++ b/packages/serialization/text/src/textSerializationWriterFactory.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SerializationWriter,
   SerializationWriterFactory,
 } from "@microsoft/kiota-abstractions";

--- a/packages/test/generatedCode/apiClient.ts
+++ b/packages/test/generatedCode/apiClient.ts
@@ -1,7 +1,9 @@
 import {UsersRequestBuilder} from './users/usersRequestBuilder';
-import {BaseRequestBuilder, enableBackingStoreForSerializationWriterFactory, ParseNodeFactoryRegistry, registerDefaultDeserializer, registerDefaultSerializer, RequestAdapter, SerializationWriterFactoryRegistry} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, ParseNodeFactoryRegistry, SerializationWriterFactoryRegistry, enableBackingStoreForSerializationWriterFactory, registerDefaultDeserializer, registerDefaultSerializer} from '@microsoft/kiota-abstractions';
+import type {RequestAdapter} from '@microsoft/kiota-abstractions';
 import {FormParseNodeFactory, FormSerializationWriterFactory} from '@microsoft/kiota-serialization-form';
 import {JsonParseNodeFactory, JsonSerializationWriterFactory} from '@microsoft/kiota-serialization-json';
+import {MultipartSerializationWriterFactory} from '@microsoft/kiota-serialization-multipart';
 import {TextParseNodeFactory, TextSerializationWriterFactory} from '@microsoft/kiota-serialization-text';
 
 /**
@@ -23,6 +25,7 @@ export class ApiClient extends BaseRequestBuilder {
         registerDefaultSerializer(JsonSerializationWriterFactory);
         registerDefaultSerializer(TextSerializationWriterFactory);
         registerDefaultSerializer(FormSerializationWriterFactory);
+        registerDefaultSerializer(MultipartSerializationWriterFactory);
         registerDefaultDeserializer(JsonParseNodeFactory);
         registerDefaultDeserializer(TextParseNodeFactory);
         registerDefaultDeserializer(FormParseNodeFactory);

--- a/packages/test/generatedCode/kiota-lock.json
+++ b/packages/test/generatedCode/kiota-lock.json
@@ -1,8 +1,8 @@
 {
-  "descriptionHash": "B9068CFB8EB21E8E1E4918F684CAE3C993B2E99585B544918BB5BDF398ECCE5DBC1ABCDA6EA77D048439C29014AA7668B276ED98B8E92740931963F3A7701241",
+  "descriptionHash": "BCA660F549E6B77563972121CEBDD92906DA590C37483649B859B2179089FD72457541C7D14A626F0144756386186D90CC2FE47E7DBF4A483C47507A82971D4C",
   "descriptionLocation": "https://raw.githubusercontent.com/microsoftgraph/msgraph-sdk-powershell/dev/openApiDocs/v1.0/Mail.yml",
   "lockFileVersion": "1.0.0",
-  "kiotaVersion": "1.3.0",
+  "kiotaVersion": "1.6.0",
   "clientClassName": "ApiClient",
   "clientNamespaceName": "ApiSdk",
   "language": "TypeScript",
@@ -11,7 +11,8 @@
   "serializers": [
     "Microsoft.Kiota.Serialization.Json.JsonSerializationWriterFactory",
     "Microsoft.Kiota.Serialization.Text.TextSerializationWriterFactory",
-    "Microsoft.Kiota.Serialization.Form.FormSerializationWriterFactory"
+    "Microsoft.Kiota.Serialization.Form.FormSerializationWriterFactory",
+    "Microsoft.Kiota.Serialization.Multipart.MultipartSerializationWriterFactory"
   ],
   "deserializers": [
     "Microsoft.Kiota.Serialization.Json.JsonParseNodeFactory",
@@ -21,7 +22,8 @@
   "structuredMimeTypes": [
     "application/json",
     "text/plain",
-    "application/x-www-form-urlencoded"
+    "application/x-www-form-urlencoded",
+    "multipart/form-data"
   ],
   "includePatterns": [],
   "excludePatterns": [],

--- a/packages/test/generatedCode/models/attachment.ts
+++ b/packages/test/generatedCode/models/attachment.ts
@@ -1,5 +1,5 @@
-import {Entity} from './entity';
-import {Parsable} from '@microsoft/kiota-abstractions';
+import type {Entity} from './entity';
+import type {Parsable} from '@microsoft/kiota-abstractions';
 
 export interface Attachment extends Entity, Parsable {
     /**

--- a/packages/test/generatedCode/models/attachmentCollectionResponse.ts
+++ b/packages/test/generatedCode/models/attachmentCollectionResponse.ts
@@ -1,5 +1,5 @@
-import {Attachment} from './attachment';
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {Attachment} from './attachment';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface AttachmentCollectionResponse extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/dateTimeTimeZone.ts
+++ b/packages/test/generatedCode/models/dateTimeTimeZone.ts
@@ -1,4 +1,4 @@
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface DateTimeTimeZone extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/deserializeIntoAttachment.ts
+++ b/packages/test/generatedCode/models/deserializeIntoAttachment.ts
@@ -1,6 +1,6 @@
-import {Attachment} from './attachment';
+import type {Attachment} from './attachment';
 import {deserializeIntoEntity} from './deserializeIntoEntity';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoAttachment(attachment: Attachment | undefined = {} as Attachment) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoAttachmentCollectionResponse.ts
+++ b/packages/test/generatedCode/models/deserializeIntoAttachmentCollectionResponse.ts
@@ -1,8 +1,8 @@
-import {Attachment} from './attachment';
-import {AttachmentCollectionResponse} from './attachmentCollectionResponse';
+import type {Attachment} from './attachment';
+import type {AttachmentCollectionResponse} from './attachmentCollectionResponse';
 import {createAttachmentFromDiscriminatorValue} from './createAttachmentFromDiscriminatorValue';
 import {serializeAttachment} from './serializeAttachment';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoAttachmentCollectionResponse(attachmentCollectionResponse: AttachmentCollectionResponse | undefined = {} as AttachmentCollectionResponse) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoDateTimeTimeZone.ts
+++ b/packages/test/generatedCode/models/deserializeIntoDateTimeTimeZone.ts
@@ -1,5 +1,5 @@
-import {DateTimeTimeZone} from './dateTimeTimeZone';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {DateTimeTimeZone} from './dateTimeTimeZone';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoDateTimeTimeZone(dateTimeTimeZone: DateTimeTimeZone | undefined = {} as DateTimeTimeZone) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoEmailAddress.ts
+++ b/packages/test/generatedCode/models/deserializeIntoEmailAddress.ts
@@ -1,5 +1,5 @@
-import {EmailAddress} from './emailAddress';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {EmailAddress} from './emailAddress';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoEmailAddress(emailAddress: EmailAddress | undefined = {} as EmailAddress) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoEntity.ts
+++ b/packages/test/generatedCode/models/deserializeIntoEntity.ts
@@ -1,5 +1,5 @@
-import {Entity} from './entity';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Entity} from './entity';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoEntity(entity: Entity | undefined = {} as Entity) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoExtension.ts
+++ b/packages/test/generatedCode/models/deserializeIntoExtension.ts
@@ -1,6 +1,6 @@
 import {deserializeIntoEntity} from './deserializeIntoEntity';
-import {Extension} from './extension';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Extension} from './extension';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoExtension(extension: Extension | undefined = {} as Extension) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoExtensionCollectionResponse.ts
+++ b/packages/test/generatedCode/models/deserializeIntoExtensionCollectionResponse.ts
@@ -1,8 +1,8 @@
 import {createExtensionFromDiscriminatorValue} from './createExtensionFromDiscriminatorValue';
-import {Extension} from './extension';
-import {ExtensionCollectionResponse} from './extensionCollectionResponse';
+import type {Extension} from './extension';
+import type {ExtensionCollectionResponse} from './extensionCollectionResponse';
 import {serializeExtension} from './serializeExtension';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoExtensionCollectionResponse(extensionCollectionResponse: ExtensionCollectionResponse | undefined = {} as ExtensionCollectionResponse) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoFollowupFlag.ts
+++ b/packages/test/generatedCode/models/deserializeIntoFollowupFlag.ts
@@ -1,9 +1,9 @@
 import {createDateTimeTimeZoneFromDiscriminatorValue} from './createDateTimeTimeZoneFromDiscriminatorValue';
-import {DateTimeTimeZone} from './dateTimeTimeZone';
-import {FollowupFlag} from './followupFlag';
+import type {DateTimeTimeZone} from './dateTimeTimeZone';
+import type {FollowupFlag} from './followupFlag';
 import {FollowupFlagStatus} from './followupFlagStatus';
 import {serializeDateTimeTimeZone} from './serializeDateTimeTimeZone';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoFollowupFlag(followupFlag: FollowupFlag | undefined = {} as FollowupFlag) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoInferenceClassification.ts
+++ b/packages/test/generatedCode/models/deserializeIntoInferenceClassification.ts
@@ -1,9 +1,9 @@
 import {createInferenceClassificationOverrideFromDiscriminatorValue} from './createInferenceClassificationOverrideFromDiscriminatorValue';
 import {deserializeIntoEntity} from './deserializeIntoEntity';
-import {InferenceClassification} from './inferenceClassification';
-import {InferenceClassificationOverride} from './inferenceClassificationOverride';
+import type {InferenceClassification} from './inferenceClassification';
+import type {InferenceClassificationOverride} from './inferenceClassificationOverride';
 import {serializeInferenceClassificationOverride} from './serializeInferenceClassificationOverride';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoInferenceClassification(inferenceClassification: InferenceClassification | undefined = {} as InferenceClassification) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoInferenceClassificationOverride.ts
+++ b/packages/test/generatedCode/models/deserializeIntoInferenceClassificationOverride.ts
@@ -1,10 +1,10 @@
 import {createEmailAddressFromDiscriminatorValue} from './createEmailAddressFromDiscriminatorValue';
 import {deserializeIntoEntity} from './deserializeIntoEntity';
-import {EmailAddress} from './emailAddress';
-import {InferenceClassificationOverride} from './inferenceClassificationOverride';
+import type {EmailAddress} from './emailAddress';
+import type {InferenceClassificationOverride} from './inferenceClassificationOverride';
 import {InferenceClassificationType} from './inferenceClassificationType';
 import {serializeEmailAddress} from './serializeEmailAddress';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoInferenceClassificationOverride(inferenceClassificationOverride: InferenceClassificationOverride | undefined = {} as InferenceClassificationOverride) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoInferenceClassificationOverrideCollectionResponse.ts
+++ b/packages/test/generatedCode/models/deserializeIntoInferenceClassificationOverrideCollectionResponse.ts
@@ -1,8 +1,8 @@
 import {createInferenceClassificationOverrideFromDiscriminatorValue} from './createInferenceClassificationOverrideFromDiscriminatorValue';
-import {InferenceClassificationOverride} from './inferenceClassificationOverride';
-import {InferenceClassificationOverrideCollectionResponse} from './inferenceClassificationOverrideCollectionResponse';
+import type {InferenceClassificationOverride} from './inferenceClassificationOverride';
+import type {InferenceClassificationOverrideCollectionResponse} from './inferenceClassificationOverrideCollectionResponse';
 import {serializeInferenceClassificationOverride} from './serializeInferenceClassificationOverride';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoInferenceClassificationOverrideCollectionResponse(inferenceClassificationOverrideCollectionResponse: InferenceClassificationOverrideCollectionResponse | undefined = {} as InferenceClassificationOverrideCollectionResponse) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoInternetMessageHeader.ts
+++ b/packages/test/generatedCode/models/deserializeIntoInternetMessageHeader.ts
@@ -1,5 +1,5 @@
-import {InternetMessageHeader} from './internetMessageHeader';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {InternetMessageHeader} from './internetMessageHeader';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoInternetMessageHeader(internetMessageHeader: InternetMessageHeader | undefined = {} as InternetMessageHeader) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoItemBody.ts
+++ b/packages/test/generatedCode/models/deserializeIntoItemBody.ts
@@ -1,6 +1,6 @@
 import {BodyType} from './bodyType';
-import {ItemBody} from './itemBody';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {ItemBody} from './itemBody';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoItemBody(itemBody: ItemBody | undefined = {} as ItemBody) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoMailFolder.ts
+++ b/packages/test/generatedCode/models/deserializeIntoMailFolder.ts
@@ -4,17 +4,17 @@ import {createMessageRuleFromDiscriminatorValue} from './createMessageRuleFromDi
 import {createMultiValueLegacyExtendedPropertyFromDiscriminatorValue} from './createMultiValueLegacyExtendedPropertyFromDiscriminatorValue';
 import {createSingleValueLegacyExtendedPropertyFromDiscriminatorValue} from './createSingleValueLegacyExtendedPropertyFromDiscriminatorValue';
 import {deserializeIntoEntity} from './deserializeIntoEntity';
-import {MailFolder} from './mailFolder';
-import {Message} from './message';
-import {MessageRule} from './messageRule';
-import {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
+import type {MailFolder} from './mailFolder';
+import type {Message} from './message';
+import type {MessageRule} from './messageRule';
+import type {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
 import {serializeMailFolder} from './serializeMailFolder';
 import {serializeMessage} from './serializeMessage';
 import {serializeMessageRule} from './serializeMessageRule';
 import {serializeMultiValueLegacyExtendedProperty} from './serializeMultiValueLegacyExtendedProperty';
 import {serializeSingleValueLegacyExtendedProperty} from './serializeSingleValueLegacyExtendedProperty';
-import {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoMailFolder(mailFolder: MailFolder | undefined = {} as MailFolder) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoMailFolderCollectionResponse.ts
+++ b/packages/test/generatedCode/models/deserializeIntoMailFolderCollectionResponse.ts
@@ -1,8 +1,8 @@
 import {createMailFolderFromDiscriminatorValue} from './createMailFolderFromDiscriminatorValue';
-import {MailFolder} from './mailFolder';
-import {MailFolderCollectionResponse} from './mailFolderCollectionResponse';
+import type {MailFolder} from './mailFolder';
+import type {MailFolderCollectionResponse} from './mailFolderCollectionResponse';
 import {serializeMailFolder} from './serializeMailFolder';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoMailFolderCollectionResponse(mailFolderCollectionResponse: MailFolderCollectionResponse | undefined = {} as MailFolderCollectionResponse) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoMessage.ts
+++ b/packages/test/generatedCode/models/deserializeIntoMessage.ts
@@ -1,4 +1,4 @@
-import {Attachment} from './attachment';
+import type {Attachment} from './attachment';
 import {createAttachmentFromDiscriminatorValue} from './createAttachmentFromDiscriminatorValue';
 import {createExtensionFromDiscriminatorValue} from './createExtensionFromDiscriminatorValue';
 import {createFollowupFlagFromDiscriminatorValue} from './createFollowupFlagFromDiscriminatorValue';
@@ -8,15 +8,15 @@ import {createMultiValueLegacyExtendedPropertyFromDiscriminatorValue} from './cr
 import {createRecipientFromDiscriminatorValue} from './createRecipientFromDiscriminatorValue';
 import {createSingleValueLegacyExtendedPropertyFromDiscriminatorValue} from './createSingleValueLegacyExtendedPropertyFromDiscriminatorValue';
 import {deserializeIntoOutlookItem} from './deserializeIntoOutlookItem';
-import {Extension} from './extension';
-import {FollowupFlag} from './followupFlag';
+import type {Extension} from './extension';
+import type {FollowupFlag} from './followupFlag';
 import {Importance} from './importance';
 import {InferenceClassificationType} from './inferenceClassificationType';
-import {InternetMessageHeader} from './internetMessageHeader';
-import {ItemBody} from './itemBody';
-import {Message} from './message';
-import {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
-import {Recipient} from './recipient';
+import type {InternetMessageHeader} from './internetMessageHeader';
+import type {ItemBody} from './itemBody';
+import type {Message} from './message';
+import type {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
+import type {Recipient} from './recipient';
 import {serializeAttachment} from './serializeAttachment';
 import {serializeExtension} from './serializeExtension';
 import {serializeFollowupFlag} from './serializeFollowupFlag';
@@ -25,8 +25,8 @@ import {serializeItemBody} from './serializeItemBody';
 import {serializeMultiValueLegacyExtendedProperty} from './serializeMultiValueLegacyExtendedProperty';
 import {serializeRecipient} from './serializeRecipient';
 import {serializeSingleValueLegacyExtendedProperty} from './serializeSingleValueLegacyExtendedProperty';
-import {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoMessage(message: Message | undefined = {} as Message) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoMessageCollectionResponse.ts
+++ b/packages/test/generatedCode/models/deserializeIntoMessageCollectionResponse.ts
@@ -1,8 +1,8 @@
 import {createMessageFromDiscriminatorValue} from './createMessageFromDiscriminatorValue';
-import {Message} from './message';
-import {MessageCollectionResponse} from './messageCollectionResponse';
+import type {Message} from './message';
+import type {MessageCollectionResponse} from './messageCollectionResponse';
 import {serializeMessage} from './serializeMessage';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoMessageCollectionResponse(messageCollectionResponse: MessageCollectionResponse | undefined = {} as MessageCollectionResponse) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoMessageRule.ts
+++ b/packages/test/generatedCode/models/deserializeIntoMessageRule.ts
@@ -1,12 +1,12 @@
 import {createMessageRuleActionsFromDiscriminatorValue} from './createMessageRuleActionsFromDiscriminatorValue';
 import {createMessageRulePredicatesFromDiscriminatorValue} from './createMessageRulePredicatesFromDiscriminatorValue';
 import {deserializeIntoEntity} from './deserializeIntoEntity';
-import {MessageRule} from './messageRule';
-import {MessageRuleActions} from './messageRuleActions';
-import {MessageRulePredicates} from './messageRulePredicates';
+import type {MessageRule} from './messageRule';
+import type {MessageRuleActions} from './messageRuleActions';
+import type {MessageRulePredicates} from './messageRulePredicates';
 import {serializeMessageRuleActions} from './serializeMessageRuleActions';
 import {serializeMessageRulePredicates} from './serializeMessageRulePredicates';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoMessageRule(messageRule: MessageRule | undefined = {} as MessageRule) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoMessageRuleActions.ts
+++ b/packages/test/generatedCode/models/deserializeIntoMessageRuleActions.ts
@@ -1,9 +1,9 @@
 import {createRecipientFromDiscriminatorValue} from './createRecipientFromDiscriminatorValue';
 import {Importance} from './importance';
-import {MessageRuleActions} from './messageRuleActions';
-import {Recipient} from './recipient';
+import type {MessageRuleActions} from './messageRuleActions';
+import type {Recipient} from './recipient';
 import {serializeRecipient} from './serializeRecipient';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoMessageRuleActions(messageRuleActions: MessageRuleActions | undefined = {} as MessageRuleActions) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoMessageRuleCollectionResponse.ts
+++ b/packages/test/generatedCode/models/deserializeIntoMessageRuleCollectionResponse.ts
@@ -1,8 +1,8 @@
 import {createMessageRuleFromDiscriminatorValue} from './createMessageRuleFromDiscriminatorValue';
-import {MessageRule} from './messageRule';
-import {MessageRuleCollectionResponse} from './messageRuleCollectionResponse';
+import type {MessageRule} from './messageRule';
+import type {MessageRuleCollectionResponse} from './messageRuleCollectionResponse';
 import {serializeMessageRule} from './serializeMessageRule';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoMessageRuleCollectionResponse(messageRuleCollectionResponse: MessageRuleCollectionResponse | undefined = {} as MessageRuleCollectionResponse) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoMessageRulePredicates.ts
+++ b/packages/test/generatedCode/models/deserializeIntoMessageRulePredicates.ts
@@ -2,13 +2,13 @@ import {createRecipientFromDiscriminatorValue} from './createRecipientFromDiscri
 import {createSizeRangeFromDiscriminatorValue} from './createSizeRangeFromDiscriminatorValue';
 import {Importance} from './importance';
 import {MessageActionFlag} from './messageActionFlag';
-import {MessageRulePredicates} from './messageRulePredicates';
-import {Recipient} from './recipient';
+import type {MessageRulePredicates} from './messageRulePredicates';
+import type {Recipient} from './recipient';
 import {Sensitivity} from './sensitivity';
 import {serializeRecipient} from './serializeRecipient';
 import {serializeSizeRange} from './serializeSizeRange';
-import {SizeRange} from './sizeRange';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {SizeRange} from './sizeRange';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoMessageRulePredicates(messageRulePredicates: MessageRulePredicates | undefined = {} as MessageRulePredicates) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoMultiValueLegacyExtendedProperty.ts
+++ b/packages/test/generatedCode/models/deserializeIntoMultiValueLegacyExtendedProperty.ts
@@ -1,6 +1,6 @@
 import {deserializeIntoEntity} from './deserializeIntoEntity';
-import {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoMultiValueLegacyExtendedProperty(multiValueLegacyExtendedProperty: MultiValueLegacyExtendedProperty | undefined = {} as MultiValueLegacyExtendedProperty) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoOutlookItem.ts
+++ b/packages/test/generatedCode/models/deserializeIntoOutlookItem.ts
@@ -1,6 +1,6 @@
 import {deserializeIntoEntity} from './deserializeIntoEntity';
-import {OutlookItem} from './outlookItem';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {OutlookItem} from './outlookItem';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoOutlookItem(outlookItem: OutlookItem | undefined = {} as OutlookItem) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoRecipient.ts
+++ b/packages/test/generatedCode/models/deserializeIntoRecipient.ts
@@ -1,8 +1,8 @@
 import {createEmailAddressFromDiscriminatorValue} from './createEmailAddressFromDiscriminatorValue';
-import {EmailAddress} from './emailAddress';
-import {Recipient} from './recipient';
+import type {EmailAddress} from './emailAddress';
+import type {Recipient} from './recipient';
 import {serializeEmailAddress} from './serializeEmailAddress';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoRecipient(recipient: Recipient | undefined = {} as Recipient) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoSingleValueLegacyExtendedProperty.ts
+++ b/packages/test/generatedCode/models/deserializeIntoSingleValueLegacyExtendedProperty.ts
@@ -1,6 +1,6 @@
 import {deserializeIntoEntity} from './deserializeIntoEntity';
-import {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoSingleValueLegacyExtendedProperty(singleValueLegacyExtendedProperty: SingleValueLegacyExtendedProperty | undefined = {} as SingleValueLegacyExtendedProperty) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/deserializeIntoSizeRange.ts
+++ b/packages/test/generatedCode/models/deserializeIntoSizeRange.ts
@@ -1,5 +1,5 @@
-import {SizeRange} from './sizeRange';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {SizeRange} from './sizeRange';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function deserializeIntoSizeRange(sizeRange: SizeRange | undefined = {} as SizeRange) : Record<string, (node: ParseNode) => void> {
     return {

--- a/packages/test/generatedCode/models/emailAddress.ts
+++ b/packages/test/generatedCode/models/emailAddress.ts
@@ -1,4 +1,4 @@
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface EmailAddress extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/entity.ts
+++ b/packages/test/generatedCode/models/entity.ts
@@ -1,4 +1,4 @@
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface Entity extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/extension.ts
+++ b/packages/test/generatedCode/models/extension.ts
@@ -1,5 +1,5 @@
-import {Entity} from './entity';
-import {Parsable} from '@microsoft/kiota-abstractions';
+import type {Entity} from './entity';
+import type {Parsable} from '@microsoft/kiota-abstractions';
 
 export interface Extension extends Entity, Parsable {
 }

--- a/packages/test/generatedCode/models/extensionCollectionResponse.ts
+++ b/packages/test/generatedCode/models/extensionCollectionResponse.ts
@@ -1,5 +1,5 @@
-import {Extension} from './extension';
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {Extension} from './extension';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionCollectionResponse extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/followupFlag.ts
+++ b/packages/test/generatedCode/models/followupFlag.ts
@@ -1,6 +1,6 @@
-import {DateTimeTimeZone} from './dateTimeTimeZone';
+import type {DateTimeTimeZone} from './dateTimeTimeZone';
 import {FollowupFlagStatus} from './followupFlagStatus';
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface FollowupFlag extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/inferenceClassification.ts
+++ b/packages/test/generatedCode/models/inferenceClassification.ts
@@ -1,6 +1,6 @@
-import {Entity} from './entity';
-import {InferenceClassificationOverride} from './inferenceClassificationOverride';
-import {Parsable} from '@microsoft/kiota-abstractions';
+import type {Entity} from './entity';
+import type {InferenceClassificationOverride} from './inferenceClassificationOverride';
+import type {Parsable} from '@microsoft/kiota-abstractions';
 
 export interface InferenceClassification extends Entity, Parsable {
     /**

--- a/packages/test/generatedCode/models/inferenceClassificationOverride.ts
+++ b/packages/test/generatedCode/models/inferenceClassificationOverride.ts
@@ -1,7 +1,7 @@
-import {EmailAddress} from './emailAddress';
-import {Entity} from './entity';
+import type {EmailAddress} from './emailAddress';
+import type {Entity} from './entity';
 import {InferenceClassificationType} from './inferenceClassificationType';
-import {Parsable} from '@microsoft/kiota-abstractions';
+import type {Parsable} from '@microsoft/kiota-abstractions';
 
 export interface InferenceClassificationOverride extends Entity, Parsable {
     /**

--- a/packages/test/generatedCode/models/inferenceClassificationOverrideCollectionResponse.ts
+++ b/packages/test/generatedCode/models/inferenceClassificationOverrideCollectionResponse.ts
@@ -1,5 +1,5 @@
-import {InferenceClassificationOverride} from './inferenceClassificationOverride';
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {InferenceClassificationOverride} from './inferenceClassificationOverride';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface InferenceClassificationOverrideCollectionResponse extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/internetMessageHeader.ts
+++ b/packages/test/generatedCode/models/internetMessageHeader.ts
@@ -1,4 +1,4 @@
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface InternetMessageHeader extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/itemBody.ts
+++ b/packages/test/generatedCode/models/itemBody.ts
@@ -1,5 +1,5 @@
 import {BodyType} from './bodyType';
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface ItemBody extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/mailFolder.ts
+++ b/packages/test/generatedCode/models/mailFolder.ts
@@ -1,9 +1,9 @@
-import {Entity} from './entity';
-import {Message} from './message';
-import {MessageRule} from './messageRule';
-import {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
-import {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
-import {Parsable} from '@microsoft/kiota-abstractions';
+import type {Entity} from './entity';
+import type {Message} from './message';
+import type {MessageRule} from './messageRule';
+import type {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
+import type {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
+import type {Parsable} from '@microsoft/kiota-abstractions';
 
 export interface MailFolder extends Entity, Parsable {
     /**

--- a/packages/test/generatedCode/models/mailFolderCollectionResponse.ts
+++ b/packages/test/generatedCode/models/mailFolderCollectionResponse.ts
@@ -1,5 +1,5 @@
-import {MailFolder} from './mailFolder';
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {MailFolder} from './mailFolder';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface MailFolderCollectionResponse extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/message.ts
+++ b/packages/test/generatedCode/models/message.ts
@@ -1,15 +1,15 @@
-import {Attachment} from './attachment';
-import {Extension} from './extension';
-import {FollowupFlag} from './followupFlag';
+import type {Attachment} from './attachment';
+import type {Extension} from './extension';
+import type {FollowupFlag} from './followupFlag';
 import {Importance} from './importance';
 import {InferenceClassificationType} from './inferenceClassificationType';
-import {InternetMessageHeader} from './internetMessageHeader';
-import {ItemBody} from './itemBody';
-import {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
-import {OutlookItem} from './outlookItem';
-import {Recipient} from './recipient';
-import {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
-import {Parsable} from '@microsoft/kiota-abstractions';
+import type {InternetMessageHeader} from './internetMessageHeader';
+import type {ItemBody} from './itemBody';
+import type {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
+import type {OutlookItem} from './outlookItem';
+import type {Recipient} from './recipient';
+import type {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
+import type {Parsable} from '@microsoft/kiota-abstractions';
 
 export interface Message extends OutlookItem, Parsable {
     /**

--- a/packages/test/generatedCode/models/messageCollectionResponse.ts
+++ b/packages/test/generatedCode/models/messageCollectionResponse.ts
@@ -1,5 +1,5 @@
-import {Message} from './message';
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {Message} from './message';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface MessageCollectionResponse extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/messageRule.ts
+++ b/packages/test/generatedCode/models/messageRule.ts
@@ -1,7 +1,7 @@
-import {Entity} from './entity';
-import {MessageRuleActions} from './messageRuleActions';
-import {MessageRulePredicates} from './messageRulePredicates';
-import {Parsable} from '@microsoft/kiota-abstractions';
+import type {Entity} from './entity';
+import type {MessageRuleActions} from './messageRuleActions';
+import type {MessageRulePredicates} from './messageRulePredicates';
+import type {Parsable} from '@microsoft/kiota-abstractions';
 
 export interface MessageRule extends Entity, Parsable {
     /**

--- a/packages/test/generatedCode/models/messageRuleActions.ts
+++ b/packages/test/generatedCode/models/messageRuleActions.ts
@@ -1,6 +1,6 @@
 import {Importance} from './importance';
-import {Recipient} from './recipient';
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {Recipient} from './recipient';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface MessageRuleActions extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/messageRuleCollectionResponse.ts
+++ b/packages/test/generatedCode/models/messageRuleCollectionResponse.ts
@@ -1,5 +1,5 @@
-import {MessageRule} from './messageRule';
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {MessageRule} from './messageRule';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface MessageRuleCollectionResponse extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/messageRulePredicates.ts
+++ b/packages/test/generatedCode/models/messageRulePredicates.ts
@@ -1,9 +1,9 @@
 import {Importance} from './importance';
 import {MessageActionFlag} from './messageActionFlag';
-import {Recipient} from './recipient';
+import type {Recipient} from './recipient';
 import {Sensitivity} from './sensitivity';
-import {SizeRange} from './sizeRange';
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {SizeRange} from './sizeRange';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface MessageRulePredicates extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/multiValueLegacyExtendedProperty.ts
+++ b/packages/test/generatedCode/models/multiValueLegacyExtendedProperty.ts
@@ -1,5 +1,5 @@
-import {Entity} from './entity';
-import {Parsable} from '@microsoft/kiota-abstractions';
+import type {Entity} from './entity';
+import type {Parsable} from '@microsoft/kiota-abstractions';
 
 export interface MultiValueLegacyExtendedProperty extends Entity, Parsable {
     /**

--- a/packages/test/generatedCode/models/outlookItem.ts
+++ b/packages/test/generatedCode/models/outlookItem.ts
@@ -1,5 +1,5 @@
-import {Entity} from './entity';
-import {Parsable} from '@microsoft/kiota-abstractions';
+import type {Entity} from './entity';
+import type {Parsable} from '@microsoft/kiota-abstractions';
 
 export interface OutlookItem extends Entity, Parsable {
     /**

--- a/packages/test/generatedCode/models/recipient.ts
+++ b/packages/test/generatedCode/models/recipient.ts
@@ -1,5 +1,5 @@
-import {EmailAddress} from './emailAddress';
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {EmailAddress} from './emailAddress';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface Recipient extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/models/serializeAttachment.ts
+++ b/packages/test/generatedCode/models/serializeAttachment.ts
@@ -1,6 +1,6 @@
-import {Attachment} from './attachment';
+import type {Attachment} from './attachment';
 import {serializeEntity} from './serializeEntity';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeAttachment(writer: SerializationWriter, attachment: Attachment | undefined = {} as Attachment) : void {
         serializeEntity(writer, attachment)

--- a/packages/test/generatedCode/models/serializeAttachmentCollectionResponse.ts
+++ b/packages/test/generatedCode/models/serializeAttachmentCollectionResponse.ts
@@ -1,7 +1,7 @@
-import {Attachment} from './attachment';
-import {AttachmentCollectionResponse} from './attachmentCollectionResponse';
+import type {Attachment} from './attachment';
+import type {AttachmentCollectionResponse} from './attachmentCollectionResponse';
 import {serializeAttachment} from './serializeAttachment';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeAttachmentCollectionResponse(writer: SerializationWriter, attachmentCollectionResponse: AttachmentCollectionResponse | undefined = {} as AttachmentCollectionResponse) : void {
         writer.writeStringValue("@odata.nextLink", attachmentCollectionResponse.odataNextLink);

--- a/packages/test/generatedCode/models/serializeDateTimeTimeZone.ts
+++ b/packages/test/generatedCode/models/serializeDateTimeTimeZone.ts
@@ -1,5 +1,5 @@
-import {DateTimeTimeZone} from './dateTimeTimeZone';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {DateTimeTimeZone} from './dateTimeTimeZone';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeDateTimeTimeZone(writer: SerializationWriter, dateTimeTimeZone: DateTimeTimeZone | undefined = {} as DateTimeTimeZone) : void {
         writer.writeStringValue("dateTime", dateTimeTimeZone.dateTime);

--- a/packages/test/generatedCode/models/serializeEmailAddress.ts
+++ b/packages/test/generatedCode/models/serializeEmailAddress.ts
@@ -1,5 +1,5 @@
-import {EmailAddress} from './emailAddress';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {EmailAddress} from './emailAddress';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeEmailAddress(writer: SerializationWriter, emailAddress: EmailAddress | undefined = {} as EmailAddress) : void {
         writer.writeStringValue("address", emailAddress.address);

--- a/packages/test/generatedCode/models/serializeEntity.ts
+++ b/packages/test/generatedCode/models/serializeEntity.ts
@@ -1,5 +1,5 @@
-import {Entity} from './entity';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Entity} from './entity';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeEntity(writer: SerializationWriter, entity: Entity | undefined = {} as Entity) : void {
         writer.writeStringValue("id", entity.id);

--- a/packages/test/generatedCode/models/serializeExtension.ts
+++ b/packages/test/generatedCode/models/serializeExtension.ts
@@ -1,6 +1,6 @@
-import {Extension} from './extension';
+import type {Extension} from './extension';
 import {serializeEntity} from './serializeEntity';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeExtension(writer: SerializationWriter, extension: Extension | undefined = {} as Extension) : void {
         serializeEntity(writer, extension)

--- a/packages/test/generatedCode/models/serializeExtensionCollectionResponse.ts
+++ b/packages/test/generatedCode/models/serializeExtensionCollectionResponse.ts
@@ -1,7 +1,7 @@
-import {Extension} from './extension';
-import {ExtensionCollectionResponse} from './extensionCollectionResponse';
+import type {Extension} from './extension';
+import type {ExtensionCollectionResponse} from './extensionCollectionResponse';
 import {serializeExtension} from './serializeExtension';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeExtensionCollectionResponse(writer: SerializationWriter, extensionCollectionResponse: ExtensionCollectionResponse | undefined = {} as ExtensionCollectionResponse) : void {
         writer.writeStringValue("@odata.nextLink", extensionCollectionResponse.odataNextLink);

--- a/packages/test/generatedCode/models/serializeFollowupFlag.ts
+++ b/packages/test/generatedCode/models/serializeFollowupFlag.ts
@@ -1,8 +1,8 @@
-import {DateTimeTimeZone} from './dateTimeTimeZone';
-import {FollowupFlag} from './followupFlag';
+import type {DateTimeTimeZone} from './dateTimeTimeZone';
+import type {FollowupFlag} from './followupFlag';
 import {FollowupFlagStatus} from './followupFlagStatus';
 import {serializeDateTimeTimeZone} from './serializeDateTimeTimeZone';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeFollowupFlag(writer: SerializationWriter, followupFlag: FollowupFlag | undefined = {} as FollowupFlag) : void {
         writer.writeObjectValue<DateTimeTimeZone>("completedDateTime", followupFlag.completedDateTime, serializeDateTimeTimeZone);

--- a/packages/test/generatedCode/models/serializeInferenceClassification.ts
+++ b/packages/test/generatedCode/models/serializeInferenceClassification.ts
@@ -1,8 +1,8 @@
-import {InferenceClassification} from './inferenceClassification';
-import {InferenceClassificationOverride} from './inferenceClassificationOverride';
+import type {InferenceClassification} from './inferenceClassification';
+import type {InferenceClassificationOverride} from './inferenceClassificationOverride';
 import {serializeEntity} from './serializeEntity';
 import {serializeInferenceClassificationOverride} from './serializeInferenceClassificationOverride';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeInferenceClassification(writer: SerializationWriter, inferenceClassification: InferenceClassification | undefined = {} as InferenceClassification) : void {
         serializeEntity(writer, inferenceClassification)

--- a/packages/test/generatedCode/models/serializeInferenceClassificationOverride.ts
+++ b/packages/test/generatedCode/models/serializeInferenceClassificationOverride.ts
@@ -1,9 +1,9 @@
-import {EmailAddress} from './emailAddress';
-import {InferenceClassificationOverride} from './inferenceClassificationOverride';
+import type {EmailAddress} from './emailAddress';
+import type {InferenceClassificationOverride} from './inferenceClassificationOverride';
 import {InferenceClassificationType} from './inferenceClassificationType';
 import {serializeEmailAddress} from './serializeEmailAddress';
 import {serializeEntity} from './serializeEntity';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeInferenceClassificationOverride(writer: SerializationWriter, inferenceClassificationOverride: InferenceClassificationOverride | undefined = {} as InferenceClassificationOverride) : void {
         serializeEntity(writer, inferenceClassificationOverride)

--- a/packages/test/generatedCode/models/serializeInferenceClassificationOverrideCollectionResponse.ts
+++ b/packages/test/generatedCode/models/serializeInferenceClassificationOverrideCollectionResponse.ts
@@ -1,7 +1,7 @@
-import {InferenceClassificationOverride} from './inferenceClassificationOverride';
-import {InferenceClassificationOverrideCollectionResponse} from './inferenceClassificationOverrideCollectionResponse';
+import type {InferenceClassificationOverride} from './inferenceClassificationOverride';
+import type {InferenceClassificationOverrideCollectionResponse} from './inferenceClassificationOverrideCollectionResponse';
 import {serializeInferenceClassificationOverride} from './serializeInferenceClassificationOverride';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeInferenceClassificationOverrideCollectionResponse(writer: SerializationWriter, inferenceClassificationOverrideCollectionResponse: InferenceClassificationOverrideCollectionResponse | undefined = {} as InferenceClassificationOverrideCollectionResponse) : void {
         writer.writeStringValue("@odata.nextLink", inferenceClassificationOverrideCollectionResponse.odataNextLink);

--- a/packages/test/generatedCode/models/serializeInternetMessageHeader.ts
+++ b/packages/test/generatedCode/models/serializeInternetMessageHeader.ts
@@ -1,5 +1,5 @@
-import {InternetMessageHeader} from './internetMessageHeader';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {InternetMessageHeader} from './internetMessageHeader';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeInternetMessageHeader(writer: SerializationWriter, internetMessageHeader: InternetMessageHeader | undefined = {} as InternetMessageHeader) : void {
         writer.writeStringValue("name", internetMessageHeader.name);

--- a/packages/test/generatedCode/models/serializeItemBody.ts
+++ b/packages/test/generatedCode/models/serializeItemBody.ts
@@ -1,6 +1,6 @@
 import {BodyType} from './bodyType';
-import {ItemBody} from './itemBody';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {ItemBody} from './itemBody';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeItemBody(writer: SerializationWriter, itemBody: ItemBody | undefined = {} as ItemBody) : void {
         writer.writeStringValue("content", itemBody.content);

--- a/packages/test/generatedCode/models/serializeMailFolder.ts
+++ b/packages/test/generatedCode/models/serializeMailFolder.ts
@@ -1,14 +1,14 @@
-import {MailFolder} from './mailFolder';
-import {Message} from './message';
-import {MessageRule} from './messageRule';
-import {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
+import type {MailFolder} from './mailFolder';
+import type {Message} from './message';
+import type {MessageRule} from './messageRule';
+import type {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
 import {serializeEntity} from './serializeEntity';
 import {serializeMessage} from './serializeMessage';
 import {serializeMessageRule} from './serializeMessageRule';
 import {serializeMultiValueLegacyExtendedProperty} from './serializeMultiValueLegacyExtendedProperty';
 import {serializeSingleValueLegacyExtendedProperty} from './serializeSingleValueLegacyExtendedProperty';
-import {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeMailFolder(writer: SerializationWriter, mailFolder: MailFolder | undefined = {} as MailFolder) : void {
         serializeEntity(writer, mailFolder)

--- a/packages/test/generatedCode/models/serializeMailFolderCollectionResponse.ts
+++ b/packages/test/generatedCode/models/serializeMailFolderCollectionResponse.ts
@@ -1,7 +1,7 @@
-import {MailFolder} from './mailFolder';
-import {MailFolderCollectionResponse} from './mailFolderCollectionResponse';
+import type {MailFolder} from './mailFolder';
+import type {MailFolderCollectionResponse} from './mailFolderCollectionResponse';
 import {serializeMailFolder} from './serializeMailFolder';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeMailFolderCollectionResponse(writer: SerializationWriter, mailFolderCollectionResponse: MailFolderCollectionResponse | undefined = {} as MailFolderCollectionResponse) : void {
         writer.writeStringValue("@odata.nextLink", mailFolderCollectionResponse.odataNextLink);

--- a/packages/test/generatedCode/models/serializeMessage.ts
+++ b/packages/test/generatedCode/models/serializeMessage.ts
@@ -1,13 +1,13 @@
-import {Attachment} from './attachment';
-import {Extension} from './extension';
-import {FollowupFlag} from './followupFlag';
+import type {Attachment} from './attachment';
+import type {Extension} from './extension';
+import type {FollowupFlag} from './followupFlag';
 import {Importance} from './importance';
 import {InferenceClassificationType} from './inferenceClassificationType';
-import {InternetMessageHeader} from './internetMessageHeader';
-import {ItemBody} from './itemBody';
-import {Message} from './message';
-import {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
-import {Recipient} from './recipient';
+import type {InternetMessageHeader} from './internetMessageHeader';
+import type {ItemBody} from './itemBody';
+import type {Message} from './message';
+import type {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
+import type {Recipient} from './recipient';
 import {serializeAttachment} from './serializeAttachment';
 import {serializeExtension} from './serializeExtension';
 import {serializeFollowupFlag} from './serializeFollowupFlag';
@@ -17,8 +17,8 @@ import {serializeMultiValueLegacyExtendedProperty} from './serializeMultiValueLe
 import {serializeOutlookItem} from './serializeOutlookItem';
 import {serializeRecipient} from './serializeRecipient';
 import {serializeSingleValueLegacyExtendedProperty} from './serializeSingleValueLegacyExtendedProperty';
-import {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeMessage(writer: SerializationWriter, message: Message | undefined = {} as Message) : void {
         serializeOutlookItem(writer, message)

--- a/packages/test/generatedCode/models/serializeMessageCollectionResponse.ts
+++ b/packages/test/generatedCode/models/serializeMessageCollectionResponse.ts
@@ -1,7 +1,7 @@
-import {Message} from './message';
-import {MessageCollectionResponse} from './messageCollectionResponse';
+import type {Message} from './message';
+import type {MessageCollectionResponse} from './messageCollectionResponse';
 import {serializeMessage} from './serializeMessage';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeMessageCollectionResponse(writer: SerializationWriter, messageCollectionResponse: MessageCollectionResponse | undefined = {} as MessageCollectionResponse) : void {
         writer.writeStringValue("@odata.nextLink", messageCollectionResponse.odataNextLink);

--- a/packages/test/generatedCode/models/serializeMessageRule.ts
+++ b/packages/test/generatedCode/models/serializeMessageRule.ts
@@ -1,10 +1,10 @@
-import {MessageRule} from './messageRule';
-import {MessageRuleActions} from './messageRuleActions';
-import {MessageRulePredicates} from './messageRulePredicates';
+import type {MessageRule} from './messageRule';
+import type {MessageRuleActions} from './messageRuleActions';
+import type {MessageRulePredicates} from './messageRulePredicates';
 import {serializeEntity} from './serializeEntity';
 import {serializeMessageRuleActions} from './serializeMessageRuleActions';
 import {serializeMessageRulePredicates} from './serializeMessageRulePredicates';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeMessageRule(writer: SerializationWriter, messageRule: MessageRule | undefined = {} as MessageRule) : void {
         serializeEntity(writer, messageRule)

--- a/packages/test/generatedCode/models/serializeMessageRuleActions.ts
+++ b/packages/test/generatedCode/models/serializeMessageRuleActions.ts
@@ -1,8 +1,8 @@
 import {Importance} from './importance';
-import {MessageRuleActions} from './messageRuleActions';
-import {Recipient} from './recipient';
+import type {MessageRuleActions} from './messageRuleActions';
+import type {Recipient} from './recipient';
 import {serializeRecipient} from './serializeRecipient';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeMessageRuleActions(writer: SerializationWriter, messageRuleActions: MessageRuleActions | undefined = {} as MessageRuleActions) : void {
         writer.writeCollectionOfPrimitiveValues<string>("assignCategories", messageRuleActions.assignCategories);

--- a/packages/test/generatedCode/models/serializeMessageRuleCollectionResponse.ts
+++ b/packages/test/generatedCode/models/serializeMessageRuleCollectionResponse.ts
@@ -1,7 +1,7 @@
-import {MessageRule} from './messageRule';
-import {MessageRuleCollectionResponse} from './messageRuleCollectionResponse';
+import type {MessageRule} from './messageRule';
+import type {MessageRuleCollectionResponse} from './messageRuleCollectionResponse';
 import {serializeMessageRule} from './serializeMessageRule';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeMessageRuleCollectionResponse(writer: SerializationWriter, messageRuleCollectionResponse: MessageRuleCollectionResponse | undefined = {} as MessageRuleCollectionResponse) : void {
         writer.writeStringValue("@odata.nextLink", messageRuleCollectionResponse.odataNextLink);

--- a/packages/test/generatedCode/models/serializeMessageRulePredicates.ts
+++ b/packages/test/generatedCode/models/serializeMessageRulePredicates.ts
@@ -1,12 +1,12 @@
 import {Importance} from './importance';
 import {MessageActionFlag} from './messageActionFlag';
-import {MessageRulePredicates} from './messageRulePredicates';
-import {Recipient} from './recipient';
+import type {MessageRulePredicates} from './messageRulePredicates';
+import type {Recipient} from './recipient';
 import {Sensitivity} from './sensitivity';
 import {serializeRecipient} from './serializeRecipient';
 import {serializeSizeRange} from './serializeSizeRange';
-import {SizeRange} from './sizeRange';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {SizeRange} from './sizeRange';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeMessageRulePredicates(writer: SerializationWriter, messageRulePredicates: MessageRulePredicates | undefined = {} as MessageRulePredicates) : void {
         writer.writeCollectionOfPrimitiveValues<string>("bodyContains", messageRulePredicates.bodyContains);

--- a/packages/test/generatedCode/models/serializeMultiValueLegacyExtendedProperty.ts
+++ b/packages/test/generatedCode/models/serializeMultiValueLegacyExtendedProperty.ts
@@ -1,6 +1,6 @@
-import {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
+import type {MultiValueLegacyExtendedProperty} from './multiValueLegacyExtendedProperty';
 import {serializeEntity} from './serializeEntity';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeMultiValueLegacyExtendedProperty(writer: SerializationWriter, multiValueLegacyExtendedProperty: MultiValueLegacyExtendedProperty | undefined = {} as MultiValueLegacyExtendedProperty) : void {
         serializeEntity(writer, multiValueLegacyExtendedProperty)

--- a/packages/test/generatedCode/models/serializeOutlookItem.ts
+++ b/packages/test/generatedCode/models/serializeOutlookItem.ts
@@ -1,6 +1,6 @@
-import {OutlookItem} from './outlookItem';
+import type {OutlookItem} from './outlookItem';
 import {serializeEntity} from './serializeEntity';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeOutlookItem(writer: SerializationWriter, outlookItem: OutlookItem | undefined = {} as OutlookItem) : void {
         serializeEntity(writer, outlookItem)

--- a/packages/test/generatedCode/models/serializeRecipient.ts
+++ b/packages/test/generatedCode/models/serializeRecipient.ts
@@ -1,7 +1,7 @@
-import {EmailAddress} from './emailAddress';
-import {Recipient} from './recipient';
+import type {EmailAddress} from './emailAddress';
+import type {Recipient} from './recipient';
 import {serializeEmailAddress} from './serializeEmailAddress';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeRecipient(writer: SerializationWriter, recipient: Recipient | undefined = {} as Recipient) : void {
         writer.writeObjectValue<EmailAddress>("emailAddress", recipient.emailAddress, serializeEmailAddress);

--- a/packages/test/generatedCode/models/serializeSingleValueLegacyExtendedProperty.ts
+++ b/packages/test/generatedCode/models/serializeSingleValueLegacyExtendedProperty.ts
@@ -1,6 +1,6 @@
 import {serializeEntity} from './serializeEntity';
-import {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
-import {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {SingleValueLegacyExtendedProperty} from './singleValueLegacyExtendedProperty';
+import type {Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeSingleValueLegacyExtendedProperty(writer: SerializationWriter, singleValueLegacyExtendedProperty: SingleValueLegacyExtendedProperty | undefined = {} as SingleValueLegacyExtendedProperty) : void {
         serializeEntity(writer, singleValueLegacyExtendedProperty)

--- a/packages/test/generatedCode/models/serializeSizeRange.ts
+++ b/packages/test/generatedCode/models/serializeSizeRange.ts
@@ -1,5 +1,5 @@
-import {SizeRange} from './sizeRange';
-import {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
+import type {SizeRange} from './sizeRange';
+import type {AdditionalDataHolder, Parsable, ParseNode, SerializationWriter} from '@microsoft/kiota-abstractions';
 
 export function serializeSizeRange(writer: SerializationWriter, sizeRange: SizeRange | undefined = {} as SizeRange) : void {
         writer.writeNumberValue("maximumSize", sizeRange.maximumSize);

--- a/packages/test/generatedCode/models/singleValueLegacyExtendedProperty.ts
+++ b/packages/test/generatedCode/models/singleValueLegacyExtendedProperty.ts
@@ -1,5 +1,5 @@
-import {Entity} from './entity';
-import {Parsable} from '@microsoft/kiota-abstractions';
+import type {Entity} from './entity';
+import type {Parsable} from '@microsoft/kiota-abstractions';
 
 export interface SingleValueLegacyExtendedProperty extends Entity, Parsable {
     /**

--- a/packages/test/generatedCode/models/sizeRange.ts
+++ b/packages/test/generatedCode/models/sizeRange.ts
@@ -1,4 +1,4 @@
-import {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
+import type {AdditionalDataHolder, Parsable} from '@microsoft/kiota-abstractions';
 
 export interface SizeRange extends AdditionalDataHolder, Parsable {
     /**

--- a/packages/test/generatedCode/users/item/inferenceClassification/inferenceClassificationRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/inferenceClassification/inferenceClassificationRequestBuilder.ts
@@ -1,11 +1,12 @@
 import {createInferenceClassificationFromDiscriminatorValue} from '../../../models/createInferenceClassificationFromDiscriminatorValue';
 import {deserializeIntoInferenceClassification} from '../../../models/deserializeIntoInferenceClassification';
-import {InferenceClassification} from '../../../models/inferenceClassification';
+import type {InferenceClassification} from '../../../models/inferenceClassification';
 import {serializeInferenceClassification} from '../../../models/serializeInferenceClassification';
 import {InferenceClassificationRequestBuilderGetRequestConfiguration} from './inferenceClassificationRequestBuilderGetRequestConfiguration';
 import {InferenceClassificationRequestBuilderPatchRequestConfiguration} from './inferenceClassificationRequestBuilderPatchRequestConfiguration';
 import {OverridesRequestBuilder} from './overrides/overridesRequestBuilder';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/inferenceClassification
@@ -42,8 +43,7 @@ export class InferenceClassificationRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of InferenceClassification
      */
-    public patch(body: InferenceClassification | undefined, requestConfiguration?: InferenceClassificationRequestBuilderPatchRequestConfiguration | undefined) : Promise<InferenceClassification | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public patch(body: InferenceClassification, requestConfiguration?: InferenceClassificationRequestBuilderPatchRequestConfiguration | undefined) : Promise<InferenceClassification | undefined> {
         const requestInfo = this.toPatchRequestInformation(
             body, requestConfiguration
         );
@@ -73,7 +73,7 @@ export class InferenceClassificationRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPatchRequestInformation(body: InferenceClassification | undefined, requestConfiguration?: InferenceClassificationRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
+    public toPatchRequestInformation(body: InferenceClassification, requestConfiguration?: InferenceClassificationRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -84,7 +84,7 @@ export class InferenceClassificationRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeInferenceClassification);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeInferenceClassification);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/inferenceClassification/inferenceClassificationRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/inferenceClassification/inferenceClassificationRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {InferenceClassificationRequestBuilderGetQueryParameters} from './inferenceClassificationRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface InferenceClassificationRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/inferenceClassification/inferenceClassificationRequestBuilderPatchRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/inferenceClassification/inferenceClassificationRequestBuilderPatchRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface InferenceClassificationRequestBuilderPatchRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/inferenceClassification/overrides/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/inferenceClassification/overrides/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/inferenceClassification/overrides/$count

--- a/packages/test/generatedCode/users/item/inferenceClassification/overrides/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/inferenceClassification/overrides/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/inferenceClassification/overrides/item/inferenceClassificationOverrideItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/inferenceClassification/overrides/item/inferenceClassificationOverrideItemRequestBuilder.ts
@@ -1,11 +1,12 @@
 import {createInferenceClassificationOverrideFromDiscriminatorValue} from '../../../../../models/createInferenceClassificationOverrideFromDiscriminatorValue';
 import {deserializeIntoInferenceClassificationOverride} from '../../../../../models/deserializeIntoInferenceClassificationOverride';
-import {InferenceClassificationOverride} from '../../../../../models/inferenceClassificationOverride';
+import type {InferenceClassificationOverride} from '../../../../../models/inferenceClassificationOverride';
 import {serializeInferenceClassificationOverride} from '../../../../../models/serializeInferenceClassificationOverride';
 import {InferenceClassificationOverrideItemRequestBuilderDeleteRequestConfiguration} from './inferenceClassificationOverrideItemRequestBuilderDeleteRequestConfiguration';
 import {InferenceClassificationOverrideItemRequestBuilderGetRequestConfiguration} from './inferenceClassificationOverrideItemRequestBuilderGetRequestConfiguration';
 import {InferenceClassificationOverrideItemRequestBuilderPatchRequestConfiguration} from './inferenceClassificationOverrideItemRequestBuilderPatchRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/inferenceClassification/overrides/{inferenceClassificationOverride-id}
@@ -23,7 +24,7 @@ export class InferenceClassificationOverrideItemRequestBuilder extends BaseReque
      * Delete an override specified by its ID.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of ArrayBuffer
-     * @see {@link https://docs.microsoft.com/graph/api/inferenceclassificationoverride-delete?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/inferenceclassificationoverride-delete?view=graph-rest-1.0|Find more info here}
      */
     public delete(requestConfiguration?: InferenceClassificationOverrideItemRequestBuilderDeleteRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
         const requestInfo = this.toDeleteRequestInformation(
@@ -43,14 +44,13 @@ export class InferenceClassificationOverrideItemRequestBuilder extends BaseReque
         return this.requestAdapter.sendAsync<InferenceClassificationOverride>(requestInfo, createInferenceClassificationOverrideFromDiscriminatorValue, undefined);
     };
     /**
-     * Change the **classifyAs** field of an override as specified. You cannot use PATCH to change any other fields in an inferenceClassificationOverride instance. If an override exists for a sender and the sender changes his/her display name, you can use POST to force an update to the name field in the existing override. If an override exists for a sender and the sender changes his/her SMTP address, deleting the existing override and creating a new one withthe new SMTP address is the only way to 'update' the override for this sender.
+     * Change the classifyAs field of an override as specified. You cannot use PATCH to change any other fields in an inferenceClassificationOverride instance. If an override exists for a sender and the sender changes his/her display name, you can use POST to force an update to the name field in the existing override. If an override exists for a sender and the sender changes his/her SMTP address, deleting the existing override and creating a new one withthe new SMTP address is the only way to 'update' the override for this sender.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of InferenceClassificationOverride
-     * @see {@link https://docs.microsoft.com/graph/api/inferenceclassificationoverride-update?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/inferenceclassificationoverride-update?view=graph-rest-1.0|Find more info here}
      */
-    public patch(body: InferenceClassificationOverride | undefined, requestConfiguration?: InferenceClassificationOverrideItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<InferenceClassificationOverride | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public patch(body: InferenceClassificationOverride, requestConfiguration?: InferenceClassificationOverrideItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<InferenceClassificationOverride | undefined> {
         const requestInfo = this.toPatchRequestInformation(
             body, requestConfiguration
         );
@@ -91,12 +91,12 @@ export class InferenceClassificationOverrideItemRequestBuilder extends BaseReque
         return requestInfo;
     };
     /**
-     * Change the **classifyAs** field of an override as specified. You cannot use PATCH to change any other fields in an inferenceClassificationOverride instance. If an override exists for a sender and the sender changes his/her display name, you can use POST to force an update to the name field in the existing override. If an override exists for a sender and the sender changes his/her SMTP address, deleting the existing override and creating a new one withthe new SMTP address is the only way to 'update' the override for this sender.
+     * Change the classifyAs field of an override as specified. You cannot use PATCH to change any other fields in an inferenceClassificationOverride instance. If an override exists for a sender and the sender changes his/her display name, you can use POST to force an update to the name field in the existing override. If an override exists for a sender and the sender changes his/her SMTP address, deleting the existing override and creating a new one withthe new SMTP address is the only way to 'update' the override for this sender.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPatchRequestInformation(body: InferenceClassificationOverride | undefined, requestConfiguration?: InferenceClassificationOverrideItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
+    public toPatchRequestInformation(body: InferenceClassificationOverride, requestConfiguration?: InferenceClassificationOverrideItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -107,7 +107,7 @@ export class InferenceClassificationOverrideItemRequestBuilder extends BaseReque
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeInferenceClassificationOverride);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeInferenceClassificationOverride);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/inferenceClassification/overrides/item/inferenceClassificationOverrideItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/inferenceClassification/overrides/item/inferenceClassificationOverrideItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface InferenceClassificationOverrideItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/inferenceClassification/overrides/item/inferenceClassificationOverrideItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/inferenceClassification/overrides/item/inferenceClassificationOverrideItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {InferenceClassificationOverrideItemRequestBuilderGetQueryParameters} from './inferenceClassificationOverrideItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface InferenceClassificationOverrideItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/inferenceClassification/overrides/item/inferenceClassificationOverrideItemRequestBuilderPatchRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/inferenceClassification/overrides/item/inferenceClassificationOverrideItemRequestBuilderPatchRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface InferenceClassificationOverrideItemRequestBuilderPatchRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/inferenceClassification/overrides/overridesRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/inferenceClassification/overrides/overridesRequestBuilder.ts
@@ -2,13 +2,14 @@ import {InferenceClassificationOverrideCollectionResponse} from '../../../../mod
 import {createInferenceClassificationOverrideCollectionResponseFromDiscriminatorValue} from '../../../../models/createInferenceClassificationOverrideCollectionResponseFromDiscriminatorValue';
 import {createInferenceClassificationOverrideFromDiscriminatorValue} from '../../../../models/createInferenceClassificationOverrideFromDiscriminatorValue';
 import {deserializeIntoInferenceClassificationOverride} from '../../../../models/deserializeIntoInferenceClassificationOverride';
-import {InferenceClassificationOverride} from '../../../../models/inferenceClassificationOverride';
+import type {InferenceClassificationOverride} from '../../../../models/inferenceClassificationOverride';
 import {serializeInferenceClassificationOverride} from '../../../../models/serializeInferenceClassificationOverride';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {InferenceClassificationOverrideItemRequestBuilder} from './item/inferenceClassificationOverrideItemRequestBuilder';
 import {OverridesRequestBuilderGetRequestConfiguration} from './overridesRequestBuilderGetRequestConfiguration';
 import {OverridesRequestBuilderPostRequestConfiguration} from './overridesRequestBuilderPostRequestConfiguration';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/inferenceClassification/overrides
@@ -22,7 +23,7 @@ export class OverridesRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.inferenceClassification.overrides.item collection
-     * @param inferenceClassificationOverrideId Unique identifier of the item
+     * @param inferenceClassificationOverrideId The unique identifier of inferenceClassificationOverride
      * @returns a InferenceClassificationOverrideItemRequestBuilder
      */
     public byInferenceClassificationOverrideId(inferenceClassificationOverrideId: string) : InferenceClassificationOverrideItemRequestBuilder {
@@ -43,7 +44,7 @@ export class OverridesRequestBuilder extends BaseRequestBuilder {
      * Get the overrides that a user has set up to always classify messages from certain senders in specific ways. Each override corresponds to an SMTP address of a sender. Initially, a user does not have any overrides.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of InferenceClassificationOverrideCollectionResponse
-     * @see {@link https://docs.microsoft.com/graph/api/inferenceclassification-list-overrides?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/inferenceclassification-list-overrides?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: OverridesRequestBuilderGetRequestConfiguration | undefined) : Promise<InferenceClassificationOverrideCollectionResponse | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -52,14 +53,13 @@ export class OverridesRequestBuilder extends BaseRequestBuilder {
         return this.requestAdapter.sendAsync<InferenceClassificationOverrideCollectionResponse>(requestInfo, createInferenceClassificationOverrideCollectionResponseFromDiscriminatorValue, undefined);
     };
     /**
-     * Create an override for a sender identified by an SMTP address. Future messages from that SMTP address will be consistently classifiedas specified in the override. **Note**
+     * Create an override for a sender identified by an SMTP address. Future messages from that SMTP address will be consistently classifiedas specified in the override. Note
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of InferenceClassificationOverride
-     * @see {@link https://docs.microsoft.com/graph/api/inferenceclassification-post-overrides?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/inferenceclassification-post-overrides?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: InferenceClassificationOverride | undefined, requestConfiguration?: OverridesRequestBuilderPostRequestConfiguration | undefined) : Promise<InferenceClassificationOverride | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: InferenceClassificationOverride, requestConfiguration?: OverridesRequestBuilderPostRequestConfiguration | undefined) : Promise<InferenceClassificationOverride | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
@@ -84,12 +84,12 @@ export class OverridesRequestBuilder extends BaseRequestBuilder {
         return requestInfo;
     };
     /**
-     * Create an override for a sender identified by an SMTP address. Future messages from that SMTP address will be consistently classifiedas specified in the override. **Note**
+     * Create an override for a sender identified by an SMTP address. Future messages from that SMTP address will be consistently classifiedas specified in the override. Note
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: InferenceClassificationOverride | undefined, requestConfiguration?: OverridesRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: InferenceClassificationOverride, requestConfiguration?: OverridesRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -100,7 +100,7 @@ export class OverridesRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeInferenceClassificationOverride);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeInferenceClassificationOverride);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/inferenceClassification/overrides/overridesRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/inferenceClassification/overrides/overridesRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {OverridesRequestBuilderGetQueryParameters} from './overridesRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface OverridesRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/inferenceClassification/overrides/overridesRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/inferenceClassification/overrides/overridesRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface OverridesRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/$count

--- a/packages/test/generatedCode/users/item/mailFolders/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/childFoldersRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/childFoldersRequestBuilder.ts
@@ -2,13 +2,14 @@ import {MailFolderCollectionResponse} from '../../../../../models/';
 import {createMailFolderCollectionResponseFromDiscriminatorValue} from '../../../../../models/createMailFolderCollectionResponseFromDiscriminatorValue';
 import {createMailFolderFromDiscriminatorValue} from '../../../../../models/createMailFolderFromDiscriminatorValue';
 import {deserializeIntoMailFolder} from '../../../../../models/deserializeIntoMailFolder';
-import {MailFolder} from '../../../../../models/mailFolder';
+import type {MailFolder} from '../../../../../models/mailFolder';
 import {serializeMailFolder} from '../../../../../models/serializeMailFolder';
 import {ChildFoldersRequestBuilderGetRequestConfiguration} from './childFoldersRequestBuilderGetRequestConfiguration';
 import {ChildFoldersRequestBuilderPostRequestConfiguration} from './childFoldersRequestBuilderPostRequestConfiguration';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {MailFolderItemRequestBuilder} from './item/mailFolderItemRequestBuilder';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders
@@ -22,7 +23,7 @@ export class ChildFoldersRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.mailFolders.item.childFolders.item collection
-     * @param mailFolderId1 Unique identifier of the item
+     * @param mailFolderId1 The unique identifier of mailFolder
      * @returns a MailFolderItemRequestBuilder
      */
     public byMailFolderId1(mailFolderId1: string) : MailFolderItemRequestBuilder {
@@ -37,13 +38,13 @@ export class ChildFoldersRequestBuilder extends BaseRequestBuilder {
      * @param requestAdapter The request adapter to use to execute the requests.
      */
     public constructor(pathParameters: Record<string, unknown> | string | undefined, requestAdapter: RequestAdapter) {
-        super(pathParameters, requestAdapter, "{+baseurl}/users/{user%2Did}/mailFolders/{mailFolder%2Did}/childFolders{?%24top,%24skip,%24filter,%24count,%24orderby,%24select,%24expand}");
+        super(pathParameters, requestAdapter, "{+baseurl}/users/{user%2Did}/mailFolders/{mailFolder%2Did}/childFolders{?includeHiddenFolders,%24top,%24skip,%24filter,%24count,%24orderby,%24select,%24expand}");
     };
     /**
-     * Get the folder collection under the specified folder. You can use the `.../me/mailFolders` shortcut to get the top-level folder collection and navigate to another folder. By default, this operation does not return hidden folders. Use a query parameter _includeHiddenFolders_ to include them in the response.
+     * The collection of child folders in the mailFolder.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MailFolderCollectionResponse
-     * @see {@link https://docs.microsoft.com/graph/api/mailfolder-list-childfolders?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-list-childfolders?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: ChildFoldersRequestBuilderGetRequestConfiguration | undefined) : Promise<MailFolderCollectionResponse | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -52,21 +53,20 @@ export class ChildFoldersRequestBuilder extends BaseRequestBuilder {
         return this.requestAdapter.sendAsync<MailFolderCollectionResponse>(requestInfo, createMailFolderCollectionResponseFromDiscriminatorValue, undefined);
     };
     /**
-     * Create a new mailSearchFolder in the specified user's mailbox.
+     * Use this API to create a new child mailFolder. If you intend a new folder to be hidden, you must set the isHidden property to true on creation.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MailFolder
-     * @see {@link https://docs.microsoft.com/graph/api/mailsearchfolder-post?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-post-childfolders?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: MailFolder | undefined, requestConfiguration?: ChildFoldersRequestBuilderPostRequestConfiguration | undefined) : Promise<MailFolder | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: MailFolder, requestConfiguration?: ChildFoldersRequestBuilderPostRequestConfiguration | undefined) : Promise<MailFolder | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
         return this.requestAdapter.sendAsync<MailFolder>(requestInfo, createMailFolderFromDiscriminatorValue, undefined);
     };
     /**
-     * Get the folder collection under the specified folder. You can use the `.../me/mailFolders` shortcut to get the top-level folder collection and navigate to another folder. By default, this operation does not return hidden folders. Use a query parameter _includeHiddenFolders_ to include them in the response.
+     * The collection of child folders in the mailFolder.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
@@ -84,12 +84,12 @@ export class ChildFoldersRequestBuilder extends BaseRequestBuilder {
         return requestInfo;
     };
     /**
-     * Create a new mailSearchFolder in the specified user's mailbox.
+     * Use this API to create a new child mailFolder. If you intend a new folder to be hidden, you must set the isHidden property to true on creation.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: MailFolder | undefined, requestConfiguration?: ChildFoldersRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: MailFolder, requestConfiguration?: ChildFoldersRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -100,7 +100,7 @@ export class ChildFoldersRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMailFolder);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMailFolder);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/childFoldersRequestBuilderGetQueryParameters.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/childFoldersRequestBuilderGetQueryParameters.ts
@@ -13,6 +13,10 @@ export interface ChildFoldersRequestBuilderGetQueryParameters {
      */
     filter?: string | undefined;
     /**
+     * Include Hidden Folders
+     */
+    includeHiddenFolders?: string | undefined;
+    /**
      * Order items by property values
      */
     orderby?: string[] | undefined;

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/childFoldersRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/childFoldersRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {ChildFoldersRequestBuilderGetQueryParameters} from './childFoldersRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ChildFoldersRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/childFoldersRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/childFoldersRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ChildFoldersRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/$count

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/mailFolderItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/mailFolderItemRequestBuilder.ts
@@ -1,13 +1,14 @@
 import {createMailFolderFromDiscriminatorValue} from '../../../../../../models/createMailFolderFromDiscriminatorValue';
 import {deserializeIntoMailFolder} from '../../../../../../models/deserializeIntoMailFolder';
-import {MailFolder} from '../../../../../../models/mailFolder';
+import type {MailFolder} from '../../../../../../models/mailFolder';
 import {serializeMailFolder} from '../../../../../../models/serializeMailFolder';
 import {MailFolderItemRequestBuilderDeleteRequestConfiguration} from './mailFolderItemRequestBuilderDeleteRequestConfiguration';
 import {MailFolderItemRequestBuilderGetRequestConfiguration} from './mailFolderItemRequestBuilderGetRequestConfiguration';
 import {MailFolderItemRequestBuilderPatchRequestConfiguration} from './mailFolderItemRequestBuilderPatchRequestConfiguration';
 import {MessageRulesRequestBuilder} from './messageRules/messageRulesRequestBuilder';
 import {MessagesRequestBuilder} from './messages/messagesRequestBuilder';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}
@@ -31,7 +32,7 @@ export class MailFolderItemRequestBuilder extends BaseRequestBuilder {
      * @param requestAdapter The request adapter to use to execute the requests.
      */
     public constructor(pathParameters: Record<string, unknown> | string | undefined, requestAdapter: RequestAdapter) {
-        super(pathParameters, requestAdapter, "{+baseurl}/users/{user%2Did}/mailFolders/{mailFolder%2Did}/childFolders/{mailFolder%2Did1}{?%24select,%24expand}");
+        super(pathParameters, requestAdapter, "{+baseurl}/users/{user%2Did}/mailFolders/{mailFolder%2Did}/childFolders/{mailFolder%2Did1}{?includeHiddenFolders,%24select,%24expand}");
     };
     /**
      * Delete navigation property childFolders for users
@@ -61,8 +62,7 @@ export class MailFolderItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MailFolder
      */
-    public patch(body: MailFolder | undefined, requestConfiguration?: MailFolderItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<MailFolder | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public patch(body: MailFolder, requestConfiguration?: MailFolderItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<MailFolder | undefined> {
         const requestInfo = this.toPatchRequestInformation(
             body, requestConfiguration
         );
@@ -108,7 +108,7 @@ export class MailFolderItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPatchRequestInformation(body: MailFolder | undefined, requestConfiguration?: MailFolderItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
+    public toPatchRequestInformation(body: MailFolder, requestConfiguration?: MailFolderItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -119,7 +119,7 @@ export class MailFolderItemRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMailFolder);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMailFolder);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/mailFolderItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/mailFolderItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MailFolderItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/mailFolderItemRequestBuilderGetQueryParameters.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/mailFolderItemRequestBuilderGetQueryParameters.ts
@@ -5,6 +5,10 @@ export interface MailFolderItemRequestBuilderGetQueryParameters {
      */
     expand?: string[] | undefined;
     /**
+     * Include Hidden Folders
+     */
+    includeHiddenFolders?: string | undefined;
+    /**
      * Select properties to be returned
      */
     select?: string[] | undefined;

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/mailFolderItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/mailFolderItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {MailFolderItemRequestBuilderGetQueryParameters} from './mailFolderItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MailFolderItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/mailFolderItemRequestBuilderPatchRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/mailFolderItemRequestBuilderPatchRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MailFolderItemRequestBuilderPatchRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}/messageRules/$count

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/item/messageRuleItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/item/messageRuleItemRequestBuilder.ts
@@ -1,11 +1,12 @@
 import {createMessageRuleFromDiscriminatorValue} from '../../../../../../../../models/createMessageRuleFromDiscriminatorValue';
 import {deserializeIntoMessageRule} from '../../../../../../../../models/deserializeIntoMessageRule';
-import {MessageRule} from '../../../../../../../../models/messageRule';
+import type {MessageRule} from '../../../../../../../../models/messageRule';
 import {serializeMessageRule} from '../../../../../../../../models/serializeMessageRule';
 import {MessageRuleItemRequestBuilderDeleteRequestConfiguration} from './messageRuleItemRequestBuilderDeleteRequestConfiguration';
 import {MessageRuleItemRequestBuilderGetRequestConfiguration} from './messageRuleItemRequestBuilderGetRequestConfiguration';
 import {MessageRuleItemRequestBuilderPatchRequestConfiguration} from './messageRuleItemRequestBuilderPatchRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}/messageRules/{messageRule-id}
@@ -23,7 +24,7 @@ export class MessageRuleItemRequestBuilder extends BaseRequestBuilder {
      * Delete the specified messageRule object.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of ArrayBuffer
-     * @see {@link https://docs.microsoft.com/graph/api/messagerule-delete?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/messagerule-delete?view=graph-rest-1.0|Find more info here}
      */
     public delete(requestConfiguration?: MessageRuleItemRequestBuilderDeleteRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
         const requestInfo = this.toDeleteRequestInformation(
@@ -35,7 +36,7 @@ export class MessageRuleItemRequestBuilder extends BaseRequestBuilder {
      * Get the properties and relationships of a messageRule object.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MessageRule
-     * @see {@link https://docs.microsoft.com/graph/api/messagerule-get?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/messagerule-get?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: MessageRuleItemRequestBuilderGetRequestConfiguration | undefined) : Promise<MessageRule | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -48,10 +49,9 @@ export class MessageRuleItemRequestBuilder extends BaseRequestBuilder {
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MessageRule
-     * @see {@link https://docs.microsoft.com/graph/api/messagerule-update?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/messagerule-update?view=graph-rest-1.0|Find more info here}
      */
-    public patch(body: MessageRule | undefined, requestConfiguration?: MessageRuleItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<MessageRule | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public patch(body: MessageRule, requestConfiguration?: MessageRuleItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<MessageRule | undefined> {
         const requestInfo = this.toPatchRequestInformation(
             body, requestConfiguration
         );
@@ -97,7 +97,7 @@ export class MessageRuleItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPatchRequestInformation(body: MessageRule | undefined, requestConfiguration?: MessageRuleItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
+    public toPatchRequestInformation(body: MessageRule, requestConfiguration?: MessageRuleItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -108,7 +108,7 @@ export class MessageRuleItemRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMessageRule);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMessageRule);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/item/messageRuleItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/item/messageRuleItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageRuleItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/item/messageRuleItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/item/messageRuleItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {MessageRuleItemRequestBuilderGetQueryParameters} from './messageRuleItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageRuleItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/item/messageRuleItemRequestBuilderPatchRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/item/messageRuleItemRequestBuilderPatchRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageRuleItemRequestBuilderPatchRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/messageRulesRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/messageRulesRequestBuilder.ts
@@ -2,13 +2,14 @@ import {MessageRuleCollectionResponse} from '../../../../../../../models/';
 import {createMessageRuleCollectionResponseFromDiscriminatorValue} from '../../../../../../../models/createMessageRuleCollectionResponseFromDiscriminatorValue';
 import {createMessageRuleFromDiscriminatorValue} from '../../../../../../../models/createMessageRuleFromDiscriminatorValue';
 import {deserializeIntoMessageRule} from '../../../../../../../models/deserializeIntoMessageRule';
-import {MessageRule} from '../../../../../../../models/messageRule';
+import type {MessageRule} from '../../../../../../../models/messageRule';
 import {serializeMessageRule} from '../../../../../../../models/serializeMessageRule';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {MessageRuleItemRequestBuilder} from './item/messageRuleItemRequestBuilder';
 import {MessageRulesRequestBuilderGetRequestConfiguration} from './messageRulesRequestBuilderGetRequestConfiguration';
 import {MessageRulesRequestBuilderPostRequestConfiguration} from './messageRulesRequestBuilderPostRequestConfiguration';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}/messageRules
@@ -22,7 +23,7 @@ export class MessageRulesRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.mailFolders.item.childFolders.item.messageRules.item collection
-     * @param messageRuleId Unique identifier of the item
+     * @param messageRuleId The unique identifier of messageRule
      * @returns a MessageRuleItemRequestBuilder
      */
     public byMessageRuleId(messageRuleId: string) : MessageRuleItemRequestBuilder {
@@ -43,7 +44,7 @@ export class MessageRulesRequestBuilder extends BaseRequestBuilder {
      * Get all the messageRule objects defined for the user's inbox.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MessageRuleCollectionResponse
-     * @see {@link https://docs.microsoft.com/graph/api/mailfolder-list-messagerules?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-list-messagerules?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: MessageRulesRequestBuilderGetRequestConfiguration | undefined) : Promise<MessageRuleCollectionResponse | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -56,10 +57,9 @@ export class MessageRulesRequestBuilder extends BaseRequestBuilder {
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MessageRule
-     * @see {@link https://docs.microsoft.com/graph/api/mailfolder-post-messagerules?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-post-messagerules?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: MessageRule | undefined, requestConfiguration?: MessageRulesRequestBuilderPostRequestConfiguration | undefined) : Promise<MessageRule | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: MessageRule, requestConfiguration?: MessageRulesRequestBuilderPostRequestConfiguration | undefined) : Promise<MessageRule | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
@@ -89,7 +89,7 @@ export class MessageRulesRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: MessageRule | undefined, requestConfiguration?: MessageRulesRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: MessageRule, requestConfiguration?: MessageRulesRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -100,7 +100,7 @@ export class MessageRulesRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMessageRule);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMessageRule);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/messageRulesRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/messageRulesRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {MessageRulesRequestBuilderGetQueryParameters} from './messageRulesRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageRulesRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/messageRulesRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messageRules/messageRulesRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageRulesRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}/messages/$count

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/attachmentsRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/attachmentsRequestBuilder.ts
@@ -1,5 +1,5 @@
 import {AttachmentCollectionResponse} from '../../../../../../../../../models/';
-import {Attachment} from '../../../../../../../../../models/attachment';
+import type {Attachment} from '../../../../../../../../../models/attachment';
 import {createAttachmentCollectionResponseFromDiscriminatorValue} from '../../../../../../../../../models/createAttachmentCollectionResponseFromDiscriminatorValue';
 import {createAttachmentFromDiscriminatorValue} from '../../../../../../../../../models/createAttachmentFromDiscriminatorValue';
 import {deserializeIntoAttachment} from '../../../../../../../../../models/deserializeIntoAttachment';
@@ -8,7 +8,8 @@ import {AttachmentsRequestBuilderGetRequestConfiguration} from './attachmentsReq
 import {AttachmentsRequestBuilderPostRequestConfiguration} from './attachmentsRequestBuilderPostRequestConfiguration';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {AttachmentItemRequestBuilder} from './item/attachmentItemRequestBuilder';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}/messages/{message-id}/attachments
@@ -22,7 +23,7 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.mailFolders.item.childFolders.item.messages.item.attachments.item collection
-     * @param attachmentId Unique identifier of the item
+     * @param attachmentId The unique identifier of attachment
      * @returns a AttachmentItemRequestBuilder
      */
     public byAttachmentId(attachmentId: string) : AttachmentItemRequestBuilder {
@@ -43,7 +44,7 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
      * Retrieve a list of attachment objects.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of AttachmentCollectionResponse
-     * @see {@link https://docs.microsoft.com/graph/api/eventmessage-list-attachments?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/eventmessage-list-attachments?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: AttachmentsRequestBuilderGetRequestConfiguration | undefined) : Promise<AttachmentCollectionResponse | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -56,10 +57,9 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Attachment
-     * @see {@link https://docs.microsoft.com/graph/api/message-post-attachments?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/message-post-attachments?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: Attachment | undefined, requestConfiguration?: AttachmentsRequestBuilderPostRequestConfiguration | undefined) : Promise<Attachment | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: Attachment, requestConfiguration?: AttachmentsRequestBuilderPostRequestConfiguration | undefined) : Promise<Attachment | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
@@ -89,7 +89,7 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: Attachment | undefined, requestConfiguration?: AttachmentsRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: Attachment, requestConfiguration?: AttachmentsRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -100,7 +100,7 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeAttachment);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeAttachment);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/attachmentsRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/attachmentsRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {AttachmentsRequestBuilderGetQueryParameters} from './attachmentsRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface AttachmentsRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/attachmentsRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/attachmentsRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface AttachmentsRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}/messages/{message-id}/attachments/$count

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/item/attachmentItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/item/attachmentItemRequestBuilder.ts
@@ -2,7 +2,8 @@ import {Attachment} from '../../../../../../../../../../models/';
 import {createAttachmentFromDiscriminatorValue} from '../../../../../../../../../../models/createAttachmentFromDiscriminatorValue';
 import {AttachmentItemRequestBuilderDeleteRequestConfiguration} from './attachmentItemRequestBuilderDeleteRequestConfiguration';
 import {AttachmentItemRequestBuilderGetRequestConfiguration} from './attachmentItemRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}/messages/{message-id}/attachments/{attachment-id}
@@ -31,7 +32,7 @@ export class AttachmentItemRequestBuilder extends BaseRequestBuilder {
      * Read the properties, relationships, or raw contents of an attachment that is attached to a user event, message, or group post.  An attachment can be one of the following types: All these types of attachments are derived from the attachment resource. 
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Attachment
-     * @see {@link https://docs.microsoft.com/graph/api/attachment-get?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/attachment-get?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: AttachmentItemRequestBuilderGetRequestConfiguration | undefined) : Promise<Attachment | undefined> {
         const requestInfo = this.toGetRequestInformation(

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/item/attachmentItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/item/attachmentItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface AttachmentItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/item/attachmentItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/attachments/item/attachmentItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {AttachmentItemRequestBuilderGetQueryParameters} from './attachmentItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface AttachmentItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}/messages/{message-id}/extensions/$count

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/extensionsRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/extensionsRequestBuilder.ts
@@ -2,13 +2,14 @@ import {ExtensionCollectionResponse} from '../../../../../../../../../models/';
 import {createExtensionCollectionResponseFromDiscriminatorValue} from '../../../../../../../../../models/createExtensionCollectionResponseFromDiscriminatorValue';
 import {createExtensionFromDiscriminatorValue} from '../../../../../../../../../models/createExtensionFromDiscriminatorValue';
 import {deserializeIntoExtension} from '../../../../../../../../../models/deserializeIntoExtension';
-import {Extension} from '../../../../../../../../../models/extension';
+import type {Extension} from '../../../../../../../../../models/extension';
 import {serializeExtension} from '../../../../../../../../../models/serializeExtension';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {ExtensionsRequestBuilderGetRequestConfiguration} from './extensionsRequestBuilderGetRequestConfiguration';
 import {ExtensionsRequestBuilderPostRequestConfiguration} from './extensionsRequestBuilderPostRequestConfiguration';
 import {ExtensionItemRequestBuilder} from './item/extensionItemRequestBuilder';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}/messages/{message-id}/extensions
@@ -22,7 +23,7 @@ export class ExtensionsRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.mailFolders.item.childFolders.item.messages.item.extensions.item collection
-     * @param extensionId Unique identifier of the item
+     * @param extensionId The unique identifier of extension
      * @returns a ExtensionItemRequestBuilder
      */
     public byExtensionId(extensionId: string) : ExtensionItemRequestBuilder {
@@ -51,14 +52,13 @@ export class ExtensionsRequestBuilder extends BaseRequestBuilder {
         return this.requestAdapter.sendAsync<ExtensionCollectionResponse>(requestInfo, createExtensionCollectionResponseFromDiscriminatorValue, undefined);
     };
     /**
-     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. See known limitations of open extensions for more information. The table in the Permissions section lists the resources that support open extensions.
+     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. The table in the Permissions section lists the resources that support open extensions.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Extension
-     * @see {@link https://docs.microsoft.com/graph/api/opentypeextension-post-opentypeextension?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/opentypeextension-post-opentypeextension?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: Extension | undefined, requestConfiguration?: ExtensionsRequestBuilderPostRequestConfiguration | undefined) : Promise<Extension | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: Extension, requestConfiguration?: ExtensionsRequestBuilderPostRequestConfiguration | undefined) : Promise<Extension | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
@@ -83,12 +83,12 @@ export class ExtensionsRequestBuilder extends BaseRequestBuilder {
         return requestInfo;
     };
     /**
-     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. See known limitations of open extensions for more information. The table in the Permissions section lists the resources that support open extensions.
+     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. The table in the Permissions section lists the resources that support open extensions.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: Extension | undefined, requestConfiguration?: ExtensionsRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: Extension, requestConfiguration?: ExtensionsRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -99,7 +99,7 @@ export class ExtensionsRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeExtension);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeExtension);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/extensionsRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/extensionsRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {ExtensionsRequestBuilderGetQueryParameters} from './extensionsRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionsRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/extensionsRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/extensionsRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionsRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/item/extensionItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/item/extensionItemRequestBuilder.ts
@@ -1,11 +1,12 @@
 import {createExtensionFromDiscriminatorValue} from '../../../../../../../../../../models/createExtensionFromDiscriminatorValue';
 import {deserializeIntoExtension} from '../../../../../../../../../../models/deserializeIntoExtension';
-import {Extension} from '../../../../../../../../../../models/extension';
+import type {Extension} from '../../../../../../../../../../models/extension';
 import {serializeExtension} from '../../../../../../../../../../models/serializeExtension';
 import {ExtensionItemRequestBuilderDeleteRequestConfiguration} from './extensionItemRequestBuilderDeleteRequestConfiguration';
 import {ExtensionItemRequestBuilderGetRequestConfiguration} from './extensionItemRequestBuilderGetRequestConfiguration';
 import {ExtensionItemRequestBuilderPatchRequestConfiguration} from './extensionItemRequestBuilderPatchRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}/messages/{message-id}/extensions/{extension-id}
@@ -20,10 +21,10 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
         super(pathParameters, requestAdapter, "{+baseurl}/users/{user%2Did}/mailFolders/{mailFolder%2Did}/childFolders/{mailFolder%2Did1}/messages/{message%2Did}/extensions/{extension%2Did}{?%24select,%24expand}");
     };
     /**
-     * Delete an open extension (openTypeExtension object) from the specified instance of a resource.  See the table in the Permissions section for the list of resources that support open extensions.
+     * Delete an open extension (openTypeExtension object) from the specified instance of a resource.  For the list of resources that support open extensions, see the table in the Permissions section.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of ArrayBuffer
-     * @see {@link https://docs.microsoft.com/graph/api/opentypeextension-delete?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/opentypeextension-delete?view=graph-rest-1.0|Find more info here}
      */
     public delete(requestConfiguration?: ExtensionItemRequestBuilderDeleteRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
         const requestInfo = this.toDeleteRequestInformation(
@@ -35,7 +36,7 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
      * Get an open extension (openTypeExtension object) identified by name or fully qualified name. The table in the Permissions section lists the resources that support open extensions. The following table lists the three scenarios where you can get an open extension from a supported resource instance.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Extension
-     * @see {@link https://docs.microsoft.com/graph/api/opentypeextension-get?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/opentypeextension-get?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: ExtensionItemRequestBuilderGetRequestConfiguration | undefined) : Promise<Extension | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -49,15 +50,14 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Extension
      */
-    public patch(body: Extension | undefined, requestConfiguration?: ExtensionItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<Extension | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public patch(body: Extension, requestConfiguration?: ExtensionItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<Extension | undefined> {
         const requestInfo = this.toPatchRequestInformation(
             body, requestConfiguration
         );
         return this.requestAdapter.sendAsync<Extension>(requestInfo, createExtensionFromDiscriminatorValue, undefined);
     };
     /**
-     * Delete an open extension (openTypeExtension object) from the specified instance of a resource.  See the table in the Permissions section for the list of resources that support open extensions.
+     * Delete an open extension (openTypeExtension object) from the specified instance of a resource.  For the list of resources that support open extensions, see the table in the Permissions section.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
@@ -96,7 +96,7 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPatchRequestInformation(body: Extension | undefined, requestConfiguration?: ExtensionItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
+    public toPatchRequestInformation(body: Extension, requestConfiguration?: ExtensionItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -107,7 +107,7 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeExtension);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeExtension);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/item/extensionItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/item/extensionItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/item/extensionItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/item/extensionItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {ExtensionItemRequestBuilderGetQueryParameters} from './extensionItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/item/extensionItemRequestBuilderPatchRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/extensions/item/extensionItemRequestBuilderPatchRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionItemRequestBuilderPatchRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/messageItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/messageItemRequestBuilder.ts
@@ -1,6 +1,6 @@
 import {createMessageFromDiscriminatorValue} from '../../../../../../../../models/createMessageFromDiscriminatorValue';
 import {deserializeIntoMessage} from '../../../../../../../../models/deserializeIntoMessage';
-import {Message} from '../../../../../../../../models/message';
+import type {Message} from '../../../../../../../../models/message';
 import {serializeMessage} from '../../../../../../../../models/serializeMessage';
 import {AttachmentsRequestBuilder} from './attachments/attachmentsRequestBuilder';
 import {ExtensionsRequestBuilder} from './extensions/extensionsRequestBuilder';
@@ -8,7 +8,8 @@ import {MessageItemRequestBuilderDeleteRequestConfiguration} from './messageItem
 import {MessageItemRequestBuilderGetRequestConfiguration} from './messageItemRequestBuilderGetRequestConfiguration';
 import {MessageItemRequestBuilderPatchRequestConfiguration} from './messageItemRequestBuilderPatchRequestConfiguration';
 import {ContentRequestBuilder} from './value/contentRequestBuilder';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}/messages/{message-id}
@@ -68,8 +69,7 @@ export class MessageItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Message
      */
-    public patch(body: Message | undefined, requestConfiguration?: MessageItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<Message | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public patch(body: Message, requestConfiguration?: MessageItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<Message | undefined> {
         const requestInfo = this.toPatchRequestInformation(
             body, requestConfiguration
         );
@@ -115,7 +115,7 @@ export class MessageItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPatchRequestInformation(body: Message | undefined, requestConfiguration?: MessageItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
+    public toPatchRequestInformation(body: Message, requestConfiguration?: MessageItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -126,7 +126,7 @@ export class MessageItemRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMessage);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMessage);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/messageItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/messageItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/messageItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/messageItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {MessageItemRequestBuilderGetQueryParameters} from './messageItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/messageItemRequestBuilderPatchRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/messageItemRequestBuilderPatchRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageItemRequestBuilderPatchRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/value/contentRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/value/contentRequestBuilder.ts
@@ -1,6 +1,7 @@
 import {ContentRequestBuilderGetRequestConfiguration} from './contentRequestBuilderGetRequestConfiguration';
 import {ContentRequestBuilderPutRequestConfiguration} from './contentRequestBuilderPutRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}/messages/{message-id}/$value
@@ -18,7 +19,7 @@ export class ContentRequestBuilder extends BaseRequestBuilder {
      * Get media content for the navigation property messages from users
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of ArrayBuffer
-     * @see {@link https://docs.microsoft.com/graph/api/mailfolder-list-messages?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-list-messages?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: ContentRequestBuilderGetRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -33,7 +34,6 @@ export class ContentRequestBuilder extends BaseRequestBuilder {
      * @returns a Promise of ArrayBuffer
      */
     public put(body: ArrayBuffer | undefined, requestConfiguration?: ContentRequestBuilderPutRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
         const requestInfo = this.toPutRequestInformation(
             body, requestConfiguration
         );

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/value/contentRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/value/contentRequestBuilderGetRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ContentRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/value/contentRequestBuilderPutRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/item/value/contentRequestBuilderPutRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ContentRequestBuilderPutRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/messagesRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/messagesRequestBuilder.ts
@@ -2,13 +2,14 @@ import {MessageCollectionResponse} from '../../../../../../../models/';
 import {createMessageCollectionResponseFromDiscriminatorValue} from '../../../../../../../models/createMessageCollectionResponseFromDiscriminatorValue';
 import {createMessageFromDiscriminatorValue} from '../../../../../../../models/createMessageFromDiscriminatorValue';
 import {deserializeIntoMessage} from '../../../../../../../models/deserializeIntoMessage';
-import {Message} from '../../../../../../../models/message';
+import type {Message} from '../../../../../../../models/message';
 import {serializeMessage} from '../../../../../../../models/serializeMessage';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {MessageItemRequestBuilder} from './item/messageItemRequestBuilder';
 import {MessagesRequestBuilderGetRequestConfiguration} from './messagesRequestBuilderGetRequestConfiguration';
 import {MessagesRequestBuilderPostRequestConfiguration} from './messagesRequestBuilderPostRequestConfiguration';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/childFolders/{mailFolder-id1}/messages
@@ -22,7 +23,7 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.mailFolders.item.childFolders.item.messages.item collection
-     * @param messageId Unique identifier of the item
+     * @param messageId The unique identifier of message
      * @returns a MessageItemRequestBuilder
      */
     public byMessageId(messageId: string) : MessageItemRequestBuilder {
@@ -43,7 +44,7 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
      * Get all the messages in the specified user's mailbox, or those messages in a specified folder in the mailbox.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MessageCollectionResponse
-     * @see {@link https://docs.microsoft.com/graph/api/mailfolder-list-messages?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-list-messages?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: MessagesRequestBuilderGetRequestConfiguration | undefined) : Promise<MessageCollectionResponse | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -56,10 +57,9 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Message
-     * @see {@link https://docs.microsoft.com/graph/api/mailfolder-post-messages?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-post-messages?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: Message | undefined, requestConfiguration?: MessagesRequestBuilderPostRequestConfiguration | undefined) : Promise<Message | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: Message, requestConfiguration?: MessagesRequestBuilderPostRequestConfiguration | undefined) : Promise<Message | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
@@ -89,7 +89,7 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: Message | undefined, requestConfiguration?: MessagesRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: Message, requestConfiguration?: MessagesRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -100,7 +100,7 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMessage);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMessage);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/messagesRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/messagesRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {MessagesRequestBuilderGetQueryParameters} from './messagesRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessagesRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/messagesRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/childFolders/item/messages/messagesRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessagesRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/mailFolderItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/mailFolderItemRequestBuilder.ts
@@ -1,6 +1,6 @@
 import {createMailFolderFromDiscriminatorValue} from '../../../../models/createMailFolderFromDiscriminatorValue';
 import {deserializeIntoMailFolder} from '../../../../models/deserializeIntoMailFolder';
-import {MailFolder} from '../../../../models/mailFolder';
+import type {MailFolder} from '../../../../models/mailFolder';
 import {serializeMailFolder} from '../../../../models/serializeMailFolder';
 import {ChildFoldersRequestBuilder} from './childFolders/childFoldersRequestBuilder';
 import {MailFolderItemRequestBuilderDeleteRequestConfiguration} from './mailFolderItemRequestBuilderDeleteRequestConfiguration';
@@ -8,7 +8,8 @@ import {MailFolderItemRequestBuilderGetRequestConfiguration} from './mailFolderI
 import {MailFolderItemRequestBuilderPatchRequestConfiguration} from './mailFolderItemRequestBuilderPatchRequestConfiguration';
 import {MessageRulesRequestBuilder} from './messageRules/messageRulesRequestBuilder';
 import {MessagesRequestBuilder} from './messages/messagesRequestBuilder';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}
@@ -44,7 +45,7 @@ export class MailFolderItemRequestBuilder extends BaseRequestBuilder {
      * Delete the specified mailFolder. The folder can be a mailSearchFolder. You can specify a mail folder by its folder ID, or by its well-known folder name, if one exists.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of ArrayBuffer
-     * @see {@link https://docs.microsoft.com/graph/api/mailfolder-delete?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-delete?view=graph-rest-1.0|Find more info here}
      */
     public delete(requestConfiguration?: MailFolderItemRequestBuilderDeleteRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
         const requestInfo = this.toDeleteRequestInformation(
@@ -56,7 +57,7 @@ export class MailFolderItemRequestBuilder extends BaseRequestBuilder {
      * The user's mail folders. Read-only. Nullable.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MailFolder
-     * @see {@link https://docs.microsoft.com/graph/api/mailfolder-get?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-get?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: MailFolderItemRequestBuilderGetRequestConfiguration | undefined) : Promise<MailFolder | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -69,10 +70,9 @@ export class MailFolderItemRequestBuilder extends BaseRequestBuilder {
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MailFolder
-     * @see {@link https://docs.microsoft.com/graph/api/mailsearchfolder-update?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailsearchfolder-update?view=graph-rest-1.0|Find more info here}
      */
-    public patch(body: MailFolder | undefined, requestConfiguration?: MailFolderItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<MailFolder | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public patch(body: MailFolder, requestConfiguration?: MailFolderItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<MailFolder | undefined> {
         const requestInfo = this.toPatchRequestInformation(
             body, requestConfiguration
         );
@@ -118,7 +118,7 @@ export class MailFolderItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPatchRequestInformation(body: MailFolder | undefined, requestConfiguration?: MailFolderItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
+    public toPatchRequestInformation(body: MailFolder, requestConfiguration?: MailFolderItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -129,7 +129,7 @@ export class MailFolderItemRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMailFolder);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMailFolder);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/mailFolderItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/mailFolderItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MailFolderItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/mailFolderItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/mailFolderItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {MailFolderItemRequestBuilderGetQueryParameters} from './mailFolderItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MailFolderItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/mailFolderItemRequestBuilderPatchRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/mailFolderItemRequestBuilderPatchRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MailFolderItemRequestBuilderPatchRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messageRules/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messageRules/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/messageRules/$count

--- a/packages/test/generatedCode/users/item/mailFolders/item/messageRules/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messageRules/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messageRules/item/messageRuleItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messageRules/item/messageRuleItemRequestBuilder.ts
@@ -1,11 +1,12 @@
 import {createMessageRuleFromDiscriminatorValue} from '../../../../../../models/createMessageRuleFromDiscriminatorValue';
 import {deserializeIntoMessageRule} from '../../../../../../models/deserializeIntoMessageRule';
-import {MessageRule} from '../../../../../../models/messageRule';
+import type {MessageRule} from '../../../../../../models/messageRule';
 import {serializeMessageRule} from '../../../../../../models/serializeMessageRule';
 import {MessageRuleItemRequestBuilderDeleteRequestConfiguration} from './messageRuleItemRequestBuilderDeleteRequestConfiguration';
 import {MessageRuleItemRequestBuilderGetRequestConfiguration} from './messageRuleItemRequestBuilderGetRequestConfiguration';
 import {MessageRuleItemRequestBuilderPatchRequestConfiguration} from './messageRuleItemRequestBuilderPatchRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/messageRules/{messageRule-id}
@@ -23,7 +24,7 @@ export class MessageRuleItemRequestBuilder extends BaseRequestBuilder {
      * Delete the specified messageRule object.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of ArrayBuffer
-     * @see {@link https://docs.microsoft.com/graph/api/messagerule-delete?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/messagerule-delete?view=graph-rest-1.0|Find more info here}
      */
     public delete(requestConfiguration?: MessageRuleItemRequestBuilderDeleteRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
         const requestInfo = this.toDeleteRequestInformation(
@@ -35,7 +36,7 @@ export class MessageRuleItemRequestBuilder extends BaseRequestBuilder {
      * Get the properties and relationships of a messageRule object.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MessageRule
-     * @see {@link https://docs.microsoft.com/graph/api/messagerule-get?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/messagerule-get?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: MessageRuleItemRequestBuilderGetRequestConfiguration | undefined) : Promise<MessageRule | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -48,10 +49,9 @@ export class MessageRuleItemRequestBuilder extends BaseRequestBuilder {
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MessageRule
-     * @see {@link https://docs.microsoft.com/graph/api/messagerule-update?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/messagerule-update?view=graph-rest-1.0|Find more info here}
      */
-    public patch(body: MessageRule | undefined, requestConfiguration?: MessageRuleItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<MessageRule | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public patch(body: MessageRule, requestConfiguration?: MessageRuleItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<MessageRule | undefined> {
         const requestInfo = this.toPatchRequestInformation(
             body, requestConfiguration
         );
@@ -97,7 +97,7 @@ export class MessageRuleItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPatchRequestInformation(body: MessageRule | undefined, requestConfiguration?: MessageRuleItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
+    public toPatchRequestInformation(body: MessageRule, requestConfiguration?: MessageRuleItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -108,7 +108,7 @@ export class MessageRuleItemRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMessageRule);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMessageRule);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/messageRules/item/messageRuleItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messageRules/item/messageRuleItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageRuleItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messageRules/item/messageRuleItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messageRules/item/messageRuleItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {MessageRuleItemRequestBuilderGetQueryParameters} from './messageRuleItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageRuleItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messageRules/item/messageRuleItemRequestBuilderPatchRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messageRules/item/messageRuleItemRequestBuilderPatchRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageRuleItemRequestBuilderPatchRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messageRules/messageRulesRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messageRules/messageRulesRequestBuilder.ts
@@ -2,13 +2,14 @@ import {MessageRuleCollectionResponse} from '../../../../../models/';
 import {createMessageRuleCollectionResponseFromDiscriminatorValue} from '../../../../../models/createMessageRuleCollectionResponseFromDiscriminatorValue';
 import {createMessageRuleFromDiscriminatorValue} from '../../../../../models/createMessageRuleFromDiscriminatorValue';
 import {deserializeIntoMessageRule} from '../../../../../models/deserializeIntoMessageRule';
-import {MessageRule} from '../../../../../models/messageRule';
+import type {MessageRule} from '../../../../../models/messageRule';
 import {serializeMessageRule} from '../../../../../models/serializeMessageRule';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {MessageRuleItemRequestBuilder} from './item/messageRuleItemRequestBuilder';
 import {MessageRulesRequestBuilderGetRequestConfiguration} from './messageRulesRequestBuilderGetRequestConfiguration';
 import {MessageRulesRequestBuilderPostRequestConfiguration} from './messageRulesRequestBuilderPostRequestConfiguration';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/messageRules
@@ -22,7 +23,7 @@ export class MessageRulesRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.mailFolders.item.messageRules.item collection
-     * @param messageRuleId Unique identifier of the item
+     * @param messageRuleId The unique identifier of messageRule
      * @returns a MessageRuleItemRequestBuilder
      */
     public byMessageRuleId(messageRuleId: string) : MessageRuleItemRequestBuilder {
@@ -43,7 +44,7 @@ export class MessageRulesRequestBuilder extends BaseRequestBuilder {
      * Get all the messageRule objects defined for the user's inbox.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MessageRuleCollectionResponse
-     * @see {@link https://docs.microsoft.com/graph/api/mailfolder-list-messagerules?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-list-messagerules?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: MessageRulesRequestBuilderGetRequestConfiguration | undefined) : Promise<MessageRuleCollectionResponse | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -56,10 +57,9 @@ export class MessageRulesRequestBuilder extends BaseRequestBuilder {
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MessageRule
-     * @see {@link https://docs.microsoft.com/graph/api/mailfolder-post-messagerules?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-post-messagerules?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: MessageRule | undefined, requestConfiguration?: MessageRulesRequestBuilderPostRequestConfiguration | undefined) : Promise<MessageRule | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: MessageRule, requestConfiguration?: MessageRulesRequestBuilderPostRequestConfiguration | undefined) : Promise<MessageRule | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
@@ -89,7 +89,7 @@ export class MessageRulesRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: MessageRule | undefined, requestConfiguration?: MessageRulesRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: MessageRule, requestConfiguration?: MessageRulesRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -100,7 +100,7 @@ export class MessageRulesRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMessageRule);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMessageRule);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/messageRules/messageRulesRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messageRules/messageRulesRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {MessageRulesRequestBuilderGetQueryParameters} from './messageRulesRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageRulesRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messageRules/messageRulesRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messageRules/messageRulesRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageRulesRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/messages/$count

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/attachmentsRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/attachmentsRequestBuilder.ts
@@ -1,5 +1,5 @@
 import {AttachmentCollectionResponse} from '../../../../../../../models/';
-import {Attachment} from '../../../../../../../models/attachment';
+import type {Attachment} from '../../../../../../../models/attachment';
 import {createAttachmentCollectionResponseFromDiscriminatorValue} from '../../../../../../../models/createAttachmentCollectionResponseFromDiscriminatorValue';
 import {createAttachmentFromDiscriminatorValue} from '../../../../../../../models/createAttachmentFromDiscriminatorValue';
 import {deserializeIntoAttachment} from '../../../../../../../models/deserializeIntoAttachment';
@@ -8,7 +8,8 @@ import {AttachmentsRequestBuilderGetRequestConfiguration} from './attachmentsReq
 import {AttachmentsRequestBuilderPostRequestConfiguration} from './attachmentsRequestBuilderPostRequestConfiguration';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {AttachmentItemRequestBuilder} from './item/attachmentItemRequestBuilder';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/messages/{message-id}/attachments
@@ -22,7 +23,7 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.mailFolders.item.messages.item.attachments.item collection
-     * @param attachmentId Unique identifier of the item
+     * @param attachmentId The unique identifier of attachment
      * @returns a AttachmentItemRequestBuilder
      */
     public byAttachmentId(attachmentId: string) : AttachmentItemRequestBuilder {
@@ -43,7 +44,7 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
      * Retrieve a list of attachment objects.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of AttachmentCollectionResponse
-     * @see {@link https://docs.microsoft.com/graph/api/eventmessage-list-attachments?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/eventmessage-list-attachments?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: AttachmentsRequestBuilderGetRequestConfiguration | undefined) : Promise<AttachmentCollectionResponse | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -56,10 +57,9 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Attachment
-     * @see {@link https://docs.microsoft.com/graph/api/message-post-attachments?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/message-post-attachments?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: Attachment | undefined, requestConfiguration?: AttachmentsRequestBuilderPostRequestConfiguration | undefined) : Promise<Attachment | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: Attachment, requestConfiguration?: AttachmentsRequestBuilderPostRequestConfiguration | undefined) : Promise<Attachment | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
@@ -89,7 +89,7 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: Attachment | undefined, requestConfiguration?: AttachmentsRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: Attachment, requestConfiguration?: AttachmentsRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -100,7 +100,7 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeAttachment);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeAttachment);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/attachmentsRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/attachmentsRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {AttachmentsRequestBuilderGetQueryParameters} from './attachmentsRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface AttachmentsRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/attachmentsRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/attachmentsRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface AttachmentsRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/messages/{message-id}/attachments/$count

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/item/attachmentItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/item/attachmentItemRequestBuilder.ts
@@ -2,7 +2,8 @@ import {Attachment} from '../../../../../../../../models/';
 import {createAttachmentFromDiscriminatorValue} from '../../../../../../../../models/createAttachmentFromDiscriminatorValue';
 import {AttachmentItemRequestBuilderDeleteRequestConfiguration} from './attachmentItemRequestBuilderDeleteRequestConfiguration';
 import {AttachmentItemRequestBuilderGetRequestConfiguration} from './attachmentItemRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/messages/{message-id}/attachments/{attachment-id}
@@ -31,7 +32,7 @@ export class AttachmentItemRequestBuilder extends BaseRequestBuilder {
      * Read the properties, relationships, or raw contents of an attachment that is attached to a user event, message, or group post.  An attachment can be one of the following types: All these types of attachments are derived from the attachment resource. 
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Attachment
-     * @see {@link https://docs.microsoft.com/graph/api/attachment-get?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/attachment-get?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: AttachmentItemRequestBuilderGetRequestConfiguration | undefined) : Promise<Attachment | undefined> {
         const requestInfo = this.toGetRequestInformation(

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/item/attachmentItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/item/attachmentItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface AttachmentItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/item/attachmentItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/attachments/item/attachmentItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {AttachmentItemRequestBuilderGetQueryParameters} from './attachmentItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface AttachmentItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/messages/{message-id}/extensions/$count

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/extensionsRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/extensionsRequestBuilder.ts
@@ -2,13 +2,14 @@ import {ExtensionCollectionResponse} from '../../../../../../../models/';
 import {createExtensionCollectionResponseFromDiscriminatorValue} from '../../../../../../../models/createExtensionCollectionResponseFromDiscriminatorValue';
 import {createExtensionFromDiscriminatorValue} from '../../../../../../../models/createExtensionFromDiscriminatorValue';
 import {deserializeIntoExtension} from '../../../../../../../models/deserializeIntoExtension';
-import {Extension} from '../../../../../../../models/extension';
+import type {Extension} from '../../../../../../../models/extension';
 import {serializeExtension} from '../../../../../../../models/serializeExtension';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {ExtensionsRequestBuilderGetRequestConfiguration} from './extensionsRequestBuilderGetRequestConfiguration';
 import {ExtensionsRequestBuilderPostRequestConfiguration} from './extensionsRequestBuilderPostRequestConfiguration';
 import {ExtensionItemRequestBuilder} from './item/extensionItemRequestBuilder';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/messages/{message-id}/extensions
@@ -22,7 +23,7 @@ export class ExtensionsRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.mailFolders.item.messages.item.extensions.item collection
-     * @param extensionId Unique identifier of the item
+     * @param extensionId The unique identifier of extension
      * @returns a ExtensionItemRequestBuilder
      */
     public byExtensionId(extensionId: string) : ExtensionItemRequestBuilder {
@@ -51,14 +52,13 @@ export class ExtensionsRequestBuilder extends BaseRequestBuilder {
         return this.requestAdapter.sendAsync<ExtensionCollectionResponse>(requestInfo, createExtensionCollectionResponseFromDiscriminatorValue, undefined);
     };
     /**
-     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. See known limitations of open extensions for more information. The table in the Permissions section lists the resources that support open extensions.
+     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. The table in the Permissions section lists the resources that support open extensions.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Extension
-     * @see {@link https://docs.microsoft.com/graph/api/opentypeextension-post-opentypeextension?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/opentypeextension-post-opentypeextension?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: Extension | undefined, requestConfiguration?: ExtensionsRequestBuilderPostRequestConfiguration | undefined) : Promise<Extension | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: Extension, requestConfiguration?: ExtensionsRequestBuilderPostRequestConfiguration | undefined) : Promise<Extension | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
@@ -83,12 +83,12 @@ export class ExtensionsRequestBuilder extends BaseRequestBuilder {
         return requestInfo;
     };
     /**
-     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. See known limitations of open extensions for more information. The table in the Permissions section lists the resources that support open extensions.
+     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. The table in the Permissions section lists the resources that support open extensions.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: Extension | undefined, requestConfiguration?: ExtensionsRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: Extension, requestConfiguration?: ExtensionsRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -99,7 +99,7 @@ export class ExtensionsRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeExtension);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeExtension);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/extensionsRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/extensionsRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {ExtensionsRequestBuilderGetQueryParameters} from './extensionsRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionsRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/extensionsRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/extensionsRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionsRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/item/extensionItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/item/extensionItemRequestBuilder.ts
@@ -1,11 +1,12 @@
 import {createExtensionFromDiscriminatorValue} from '../../../../../../../../models/createExtensionFromDiscriminatorValue';
 import {deserializeIntoExtension} from '../../../../../../../../models/deserializeIntoExtension';
-import {Extension} from '../../../../../../../../models/extension';
+import type {Extension} from '../../../../../../../../models/extension';
 import {serializeExtension} from '../../../../../../../../models/serializeExtension';
 import {ExtensionItemRequestBuilderDeleteRequestConfiguration} from './extensionItemRequestBuilderDeleteRequestConfiguration';
 import {ExtensionItemRequestBuilderGetRequestConfiguration} from './extensionItemRequestBuilderGetRequestConfiguration';
 import {ExtensionItemRequestBuilderPatchRequestConfiguration} from './extensionItemRequestBuilderPatchRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/messages/{message-id}/extensions/{extension-id}
@@ -20,10 +21,10 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
         super(pathParameters, requestAdapter, "{+baseurl}/users/{user%2Did}/mailFolders/{mailFolder%2Did}/messages/{message%2Did}/extensions/{extension%2Did}{?%24select,%24expand}");
     };
     /**
-     * Delete an open extension (openTypeExtension object) from the specified instance of a resource.  See the table in the Permissions section for the list of resources that support open extensions.
+     * Delete an open extension (openTypeExtension object) from the specified instance of a resource.  For the list of resources that support open extensions, see the table in the Permissions section.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of ArrayBuffer
-     * @see {@link https://docs.microsoft.com/graph/api/opentypeextension-delete?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/opentypeextension-delete?view=graph-rest-1.0|Find more info here}
      */
     public delete(requestConfiguration?: ExtensionItemRequestBuilderDeleteRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
         const requestInfo = this.toDeleteRequestInformation(
@@ -35,7 +36,7 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
      * Get an open extension (openTypeExtension object) identified by name or fully qualified name. The table in the Permissions section lists the resources that support open extensions. The following table lists the three scenarios where you can get an open extension from a supported resource instance.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Extension
-     * @see {@link https://docs.microsoft.com/graph/api/opentypeextension-get?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/opentypeextension-get?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: ExtensionItemRequestBuilderGetRequestConfiguration | undefined) : Promise<Extension | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -49,15 +50,14 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Extension
      */
-    public patch(body: Extension | undefined, requestConfiguration?: ExtensionItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<Extension | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public patch(body: Extension, requestConfiguration?: ExtensionItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<Extension | undefined> {
         const requestInfo = this.toPatchRequestInformation(
             body, requestConfiguration
         );
         return this.requestAdapter.sendAsync<Extension>(requestInfo, createExtensionFromDiscriminatorValue, undefined);
     };
     /**
-     * Delete an open extension (openTypeExtension object) from the specified instance of a resource.  See the table in the Permissions section for the list of resources that support open extensions.
+     * Delete an open extension (openTypeExtension object) from the specified instance of a resource.  For the list of resources that support open extensions, see the table in the Permissions section.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
@@ -96,7 +96,7 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPatchRequestInformation(body: Extension | undefined, requestConfiguration?: ExtensionItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
+    public toPatchRequestInformation(body: Extension, requestConfiguration?: ExtensionItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -107,7 +107,7 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeExtension);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeExtension);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/item/extensionItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/item/extensionItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/item/extensionItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/item/extensionItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {ExtensionItemRequestBuilderGetQueryParameters} from './extensionItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/item/extensionItemRequestBuilderPatchRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/extensions/item/extensionItemRequestBuilderPatchRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionItemRequestBuilderPatchRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/messageItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/messageItemRequestBuilder.ts
@@ -1,6 +1,6 @@
 import {createMessageFromDiscriminatorValue} from '../../../../../../models/createMessageFromDiscriminatorValue';
 import {deserializeIntoMessage} from '../../../../../../models/deserializeIntoMessage';
-import {Message} from '../../../../../../models/message';
+import type {Message} from '../../../../../../models/message';
 import {serializeMessage} from '../../../../../../models/serializeMessage';
 import {AttachmentsRequestBuilder} from './attachments/attachmentsRequestBuilder';
 import {ExtensionsRequestBuilder} from './extensions/extensionsRequestBuilder';
@@ -8,7 +8,8 @@ import {MessageItemRequestBuilderDeleteRequestConfiguration} from './messageItem
 import {MessageItemRequestBuilderGetRequestConfiguration} from './messageItemRequestBuilderGetRequestConfiguration';
 import {MessageItemRequestBuilderPatchRequestConfiguration} from './messageItemRequestBuilderPatchRequestConfiguration';
 import {ContentRequestBuilder} from './value/contentRequestBuilder';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/messages/{message-id}
@@ -68,8 +69,7 @@ export class MessageItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Message
      */
-    public patch(body: Message | undefined, requestConfiguration?: MessageItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<Message | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public patch(body: Message, requestConfiguration?: MessageItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<Message | undefined> {
         const requestInfo = this.toPatchRequestInformation(
             body, requestConfiguration
         );
@@ -115,7 +115,7 @@ export class MessageItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPatchRequestInformation(body: Message | undefined, requestConfiguration?: MessageItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
+    public toPatchRequestInformation(body: Message, requestConfiguration?: MessageItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -126,7 +126,7 @@ export class MessageItemRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMessage);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMessage);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/messageItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/messageItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/messageItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/messageItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {MessageItemRequestBuilderGetQueryParameters} from './messageItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/messageItemRequestBuilderPatchRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/messageItemRequestBuilderPatchRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageItemRequestBuilderPatchRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/value/contentRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/value/contentRequestBuilder.ts
@@ -1,6 +1,7 @@
 import {ContentRequestBuilderGetRequestConfiguration} from './contentRequestBuilderGetRequestConfiguration';
 import {ContentRequestBuilderPutRequestConfiguration} from './contentRequestBuilderPutRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/messages/{message-id}/$value
@@ -18,7 +19,7 @@ export class ContentRequestBuilder extends BaseRequestBuilder {
      * Get media content for the navigation property messages from users
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of ArrayBuffer
-     * @see {@link https://docs.microsoft.com/graph/api/mailfolder-list-messages?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-list-messages?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: ContentRequestBuilderGetRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -33,7 +34,6 @@ export class ContentRequestBuilder extends BaseRequestBuilder {
      * @returns a Promise of ArrayBuffer
      */
     public put(body: ArrayBuffer | undefined, requestConfiguration?: ContentRequestBuilderPutRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
         const requestInfo = this.toPutRequestInformation(
             body, requestConfiguration
         );

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/value/contentRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/value/contentRequestBuilderGetRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ContentRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/item/value/contentRequestBuilderPutRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/item/value/contentRequestBuilderPutRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ContentRequestBuilderPutRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/messagesRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/messagesRequestBuilder.ts
@@ -2,13 +2,14 @@ import {MessageCollectionResponse} from '../../../../../models/';
 import {createMessageCollectionResponseFromDiscriminatorValue} from '../../../../../models/createMessageCollectionResponseFromDiscriminatorValue';
 import {createMessageFromDiscriminatorValue} from '../../../../../models/createMessageFromDiscriminatorValue';
 import {deserializeIntoMessage} from '../../../../../models/deserializeIntoMessage';
-import {Message} from '../../../../../models/message';
+import type {Message} from '../../../../../models/message';
 import {serializeMessage} from '../../../../../models/serializeMessage';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {MessageItemRequestBuilder} from './item/messageItemRequestBuilder';
 import {MessagesRequestBuilderGetRequestConfiguration} from './messagesRequestBuilderGetRequestConfiguration';
 import {MessagesRequestBuilderPostRequestConfiguration} from './messagesRequestBuilderPostRequestConfiguration';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders/{mailFolder-id}/messages
@@ -22,7 +23,7 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.mailFolders.item.messages.item collection
-     * @param messageId Unique identifier of the item
+     * @param messageId The unique identifier of message
      * @returns a MessageItemRequestBuilder
      */
     public byMessageId(messageId: string) : MessageItemRequestBuilder {
@@ -43,7 +44,7 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
      * Get all the messages in the specified user's mailbox, or those messages in a specified folder in the mailbox.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MessageCollectionResponse
-     * @see {@link https://docs.microsoft.com/graph/api/mailfolder-list-messages?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-list-messages?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: MessagesRequestBuilderGetRequestConfiguration | undefined) : Promise<MessageCollectionResponse | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -56,10 +57,9 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Message
-     * @see {@link https://docs.microsoft.com/graph/api/mailfolder-post-messages?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/mailfolder-post-messages?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: Message | undefined, requestConfiguration?: MessagesRequestBuilderPostRequestConfiguration | undefined) : Promise<Message | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: Message, requestConfiguration?: MessagesRequestBuilderPostRequestConfiguration | undefined) : Promise<Message | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
@@ -89,7 +89,7 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: Message | undefined, requestConfiguration?: MessagesRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: Message, requestConfiguration?: MessagesRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -100,7 +100,7 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMessage);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMessage);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/messagesRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/messagesRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {MessagesRequestBuilderGetQueryParameters} from './messagesRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessagesRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/item/messages/messagesRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/item/messages/messagesRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessagesRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/mailFoldersRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/mailFoldersRequestBuilder.ts
@@ -2,13 +2,14 @@ import {MailFolderCollectionResponse} from '../../../models/';
 import {createMailFolderCollectionResponseFromDiscriminatorValue} from '../../../models/createMailFolderCollectionResponseFromDiscriminatorValue';
 import {createMailFolderFromDiscriminatorValue} from '../../../models/createMailFolderFromDiscriminatorValue';
 import {deserializeIntoMailFolder} from '../../../models/deserializeIntoMailFolder';
-import {MailFolder} from '../../../models/mailFolder';
+import type {MailFolder} from '../../../models/mailFolder';
 import {serializeMailFolder} from '../../../models/serializeMailFolder';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {MailFolderItemRequestBuilder} from './item/mailFolderItemRequestBuilder';
 import {MailFoldersRequestBuilderGetRequestConfiguration} from './mailFoldersRequestBuilderGetRequestConfiguration';
 import {MailFoldersRequestBuilderPostRequestConfiguration} from './mailFoldersRequestBuilderPostRequestConfiguration';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/mailFolders
@@ -22,7 +23,7 @@ export class MailFoldersRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.mailFolders.item collection
-     * @param mailFolderId Unique identifier of the item
+     * @param mailFolderId The unique identifier of mailFolder
      * @returns a MailFolderItemRequestBuilder
      */
     public byMailFolderId(mailFolderId: string) : MailFolderItemRequestBuilder {
@@ -43,7 +44,7 @@ export class MailFoldersRequestBuilder extends BaseRequestBuilder {
      * The user's mail folders. Read-only. Nullable.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MailFolderCollectionResponse
-     * @see {@link https://docs.microsoft.com/graph/api/user-list-mailfolders?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/user-list-mailfolders?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: MailFoldersRequestBuilderGetRequestConfiguration | undefined) : Promise<MailFolderCollectionResponse | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -52,14 +53,13 @@ export class MailFoldersRequestBuilder extends BaseRequestBuilder {
         return this.requestAdapter.sendAsync<MailFolderCollectionResponse>(requestInfo, createMailFolderCollectionResponseFromDiscriminatorValue, undefined);
     };
     /**
-     * Use this API to create a new mail folder in the root folder of the user's mailbox. If you intend a new folder to be hidden, you must set the **isHidden** property to `true` on creation.
+     * Use this API to create a new mail folder in the root folder of the user's mailbox. If you intend a new folder to be hidden, you must set the isHidden property to true on creation.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MailFolder
-     * @see {@link https://docs.microsoft.com/graph/api/user-post-mailfolders?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/user-post-mailfolders?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: MailFolder | undefined, requestConfiguration?: MailFoldersRequestBuilderPostRequestConfiguration | undefined) : Promise<MailFolder | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: MailFolder, requestConfiguration?: MailFoldersRequestBuilderPostRequestConfiguration | undefined) : Promise<MailFolder | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
@@ -84,12 +84,12 @@ export class MailFoldersRequestBuilder extends BaseRequestBuilder {
         return requestInfo;
     };
     /**
-     * Use this API to create a new mail folder in the root folder of the user's mailbox. If you intend a new folder to be hidden, you must set the **isHidden** property to `true` on creation.
+     * Use this API to create a new mail folder in the root folder of the user's mailbox. If you intend a new folder to be hidden, you must set the isHidden property to true on creation.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: MailFolder | undefined, requestConfiguration?: MailFoldersRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: MailFolder, requestConfiguration?: MailFoldersRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -100,7 +100,7 @@ export class MailFoldersRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMailFolder);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMailFolder);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/mailFolders/mailFoldersRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/mailFoldersRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {MailFoldersRequestBuilderGetQueryParameters} from './mailFoldersRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MailFoldersRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/mailFolders/mailFoldersRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/mailFolders/mailFoldersRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MailFoldersRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/messages/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/messages/$count

--- a/packages/test/generatedCode/users/item/messages/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/attachments/attachmentsRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/messages/item/attachments/attachmentsRequestBuilder.ts
@@ -1,5 +1,5 @@
 import {AttachmentCollectionResponse} from '../../../../../models/';
-import {Attachment} from '../../../../../models/attachment';
+import type {Attachment} from '../../../../../models/attachment';
 import {createAttachmentCollectionResponseFromDiscriminatorValue} from '../../../../../models/createAttachmentCollectionResponseFromDiscriminatorValue';
 import {createAttachmentFromDiscriminatorValue} from '../../../../../models/createAttachmentFromDiscriminatorValue';
 import {deserializeIntoAttachment} from '../../../../../models/deserializeIntoAttachment';
@@ -8,7 +8,8 @@ import {AttachmentsRequestBuilderGetRequestConfiguration} from './attachmentsReq
 import {AttachmentsRequestBuilderPostRequestConfiguration} from './attachmentsRequestBuilderPostRequestConfiguration';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {AttachmentItemRequestBuilder} from './item/attachmentItemRequestBuilder';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/messages/{message-id}/attachments
@@ -22,7 +23,7 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.messages.item.attachments.item collection
-     * @param attachmentId Unique identifier of the item
+     * @param attachmentId The unique identifier of attachment
      * @returns a AttachmentItemRequestBuilder
      */
     public byAttachmentId(attachmentId: string) : AttachmentItemRequestBuilder {
@@ -43,7 +44,7 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
      * Retrieve a list of attachment objects.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of AttachmentCollectionResponse
-     * @see {@link https://docs.microsoft.com/graph/api/eventmessage-list-attachments?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/eventmessage-list-attachments?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: AttachmentsRequestBuilderGetRequestConfiguration | undefined) : Promise<AttachmentCollectionResponse | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -56,10 +57,9 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Attachment
-     * @see {@link https://docs.microsoft.com/graph/api/message-post-attachments?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/message-post-attachments?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: Attachment | undefined, requestConfiguration?: AttachmentsRequestBuilderPostRequestConfiguration | undefined) : Promise<Attachment | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: Attachment, requestConfiguration?: AttachmentsRequestBuilderPostRequestConfiguration | undefined) : Promise<Attachment | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
@@ -89,7 +89,7 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: Attachment | undefined, requestConfiguration?: AttachmentsRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: Attachment, requestConfiguration?: AttachmentsRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -100,7 +100,7 @@ export class AttachmentsRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeAttachment);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeAttachment);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/messages/item/attachments/attachmentsRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/attachments/attachmentsRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {AttachmentsRequestBuilderGetQueryParameters} from './attachmentsRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface AttachmentsRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/attachments/attachmentsRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/attachments/attachmentsRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface AttachmentsRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/attachments/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/messages/item/attachments/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/messages/{message-id}/attachments/$count

--- a/packages/test/generatedCode/users/item/messages/item/attachments/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/attachments/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/attachments/item/attachmentItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/messages/item/attachments/item/attachmentItemRequestBuilder.ts
@@ -2,7 +2,8 @@ import {Attachment} from '../../../../../../models/';
 import {createAttachmentFromDiscriminatorValue} from '../../../../../../models/createAttachmentFromDiscriminatorValue';
 import {AttachmentItemRequestBuilderDeleteRequestConfiguration} from './attachmentItemRequestBuilderDeleteRequestConfiguration';
 import {AttachmentItemRequestBuilderGetRequestConfiguration} from './attachmentItemRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/messages/{message-id}/attachments/{attachment-id}
@@ -31,7 +32,7 @@ export class AttachmentItemRequestBuilder extends BaseRequestBuilder {
      * Read the properties, relationships, or raw contents of an attachment that is attached to a user event, message, or group post.  An attachment can be one of the following types: All these types of attachments are derived from the attachment resource. 
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Attachment
-     * @see {@link https://docs.microsoft.com/graph/api/attachment-get?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/attachment-get?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: AttachmentItemRequestBuilderGetRequestConfiguration | undefined) : Promise<Attachment | undefined> {
         const requestInfo = this.toGetRequestInformation(

--- a/packages/test/generatedCode/users/item/messages/item/attachments/item/attachmentItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/attachments/item/attachmentItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface AttachmentItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/attachments/item/attachmentItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/attachments/item/attachmentItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {AttachmentItemRequestBuilderGetQueryParameters} from './attachmentItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface AttachmentItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/extensions/count/countRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/messages/item/extensions/count/countRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {CountRequestBuilderGetRequestConfiguration} from './countRequestBuilderGetRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/messages/{message-id}/extensions/$count

--- a/packages/test/generatedCode/users/item/messages/item/extensions/count/countRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/extensions/count/countRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {CountRequestBuilderGetQueryParameters} from './countRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface CountRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/extensions/extensionsRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/messages/item/extensions/extensionsRequestBuilder.ts
@@ -2,13 +2,14 @@ import {ExtensionCollectionResponse} from '../../../../../models/';
 import {createExtensionCollectionResponseFromDiscriminatorValue} from '../../../../../models/createExtensionCollectionResponseFromDiscriminatorValue';
 import {createExtensionFromDiscriminatorValue} from '../../../../../models/createExtensionFromDiscriminatorValue';
 import {deserializeIntoExtension} from '../../../../../models/deserializeIntoExtension';
-import {Extension} from '../../../../../models/extension';
+import type {Extension} from '../../../../../models/extension';
 import {serializeExtension} from '../../../../../models/serializeExtension';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {ExtensionsRequestBuilderGetRequestConfiguration} from './extensionsRequestBuilderGetRequestConfiguration';
 import {ExtensionsRequestBuilderPostRequestConfiguration} from './extensionsRequestBuilderPostRequestConfiguration';
 import {ExtensionItemRequestBuilder} from './item/extensionItemRequestBuilder';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/messages/{message-id}/extensions
@@ -22,7 +23,7 @@ export class ExtensionsRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.messages.item.extensions.item collection
-     * @param extensionId Unique identifier of the item
+     * @param extensionId The unique identifier of extension
      * @returns a ExtensionItemRequestBuilder
      */
     public byExtensionId(extensionId: string) : ExtensionItemRequestBuilder {
@@ -51,14 +52,13 @@ export class ExtensionsRequestBuilder extends BaseRequestBuilder {
         return this.requestAdapter.sendAsync<ExtensionCollectionResponse>(requestInfo, createExtensionCollectionResponseFromDiscriminatorValue, undefined);
     };
     /**
-     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. See known limitations of open extensions for more information. The table in the Permissions section lists the resources that support open extensions.
+     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. The table in the Permissions section lists the resources that support open extensions.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Extension
-     * @see {@link https://docs.microsoft.com/graph/api/opentypeextension-post-opentypeextension?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/opentypeextension-post-opentypeextension?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: Extension | undefined, requestConfiguration?: ExtensionsRequestBuilderPostRequestConfiguration | undefined) : Promise<Extension | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: Extension, requestConfiguration?: ExtensionsRequestBuilderPostRequestConfiguration | undefined) : Promise<Extension | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
@@ -83,12 +83,12 @@ export class ExtensionsRequestBuilder extends BaseRequestBuilder {
         return requestInfo;
     };
     /**
-     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. See known limitations of open extensions for more information. The table in the Permissions section lists the resources that support open extensions.
+     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. The table in the Permissions section lists the resources that support open extensions.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: Extension | undefined, requestConfiguration?: ExtensionsRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: Extension, requestConfiguration?: ExtensionsRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -99,7 +99,7 @@ export class ExtensionsRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeExtension);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeExtension);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/messages/item/extensions/extensionsRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/extensions/extensionsRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {ExtensionsRequestBuilderGetQueryParameters} from './extensionsRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionsRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/extensions/extensionsRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/extensions/extensionsRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionsRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/extensions/item/extensionItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/messages/item/extensions/item/extensionItemRequestBuilder.ts
@@ -1,11 +1,12 @@
 import {createExtensionFromDiscriminatorValue} from '../../../../../../models/createExtensionFromDiscriminatorValue';
 import {deserializeIntoExtension} from '../../../../../../models/deserializeIntoExtension';
-import {Extension} from '../../../../../../models/extension';
+import type {Extension} from '../../../../../../models/extension';
 import {serializeExtension} from '../../../../../../models/serializeExtension';
 import {ExtensionItemRequestBuilderDeleteRequestConfiguration} from './extensionItemRequestBuilderDeleteRequestConfiguration';
 import {ExtensionItemRequestBuilderGetRequestConfiguration} from './extensionItemRequestBuilderGetRequestConfiguration';
 import {ExtensionItemRequestBuilderPatchRequestConfiguration} from './extensionItemRequestBuilderPatchRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/messages/{message-id}/extensions/{extension-id}
@@ -20,10 +21,10 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
         super(pathParameters, requestAdapter, "{+baseurl}/users/{user%2Did}/messages/{message%2Did}/extensions/{extension%2Did}{?%24select,%24expand}");
     };
     /**
-     * Delete an open extension (openTypeExtension object) from the specified instance of a resource.  See the table in the Permissions section for the list of resources that support open extensions.
+     * Delete an open extension (openTypeExtension object) from the specified instance of a resource.  For the list of resources that support open extensions, see the table in the Permissions section.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of ArrayBuffer
-     * @see {@link https://docs.microsoft.com/graph/api/opentypeextension-delete?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/opentypeextension-delete?view=graph-rest-1.0|Find more info here}
      */
     public delete(requestConfiguration?: ExtensionItemRequestBuilderDeleteRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
         const requestInfo = this.toDeleteRequestInformation(
@@ -35,7 +36,7 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
      * Get an open extension (openTypeExtension object) identified by name or fully qualified name. The table in the Permissions section lists the resources that support open extensions. The following table lists the three scenarios where you can get an open extension from a supported resource instance.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Extension
-     * @see {@link https://docs.microsoft.com/graph/api/opentypeextension-get?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/opentypeextension-get?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: ExtensionItemRequestBuilderGetRequestConfiguration | undefined) : Promise<Extension | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -49,15 +50,14 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Extension
      */
-    public patch(body: Extension | undefined, requestConfiguration?: ExtensionItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<Extension | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public patch(body: Extension, requestConfiguration?: ExtensionItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<Extension | undefined> {
         const requestInfo = this.toPatchRequestInformation(
             body, requestConfiguration
         );
         return this.requestAdapter.sendAsync<Extension>(requestInfo, createExtensionFromDiscriminatorValue, undefined);
     };
     /**
-     * Delete an open extension (openTypeExtension object) from the specified instance of a resource.  See the table in the Permissions section for the list of resources that support open extensions.
+     * Delete an open extension (openTypeExtension object) from the specified instance of a resource.  For the list of resources that support open extensions, see the table in the Permissions section.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
@@ -96,7 +96,7 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPatchRequestInformation(body: Extension | undefined, requestConfiguration?: ExtensionItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
+    public toPatchRequestInformation(body: Extension, requestConfiguration?: ExtensionItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -107,7 +107,7 @@ export class ExtensionItemRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeExtension);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeExtension);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/messages/item/extensions/item/extensionItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/extensions/item/extensionItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/extensions/item/extensionItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/extensions/item/extensionItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {ExtensionItemRequestBuilderGetQueryParameters} from './extensionItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/extensions/item/extensionItemRequestBuilderPatchRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/extensions/item/extensionItemRequestBuilderPatchRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ExtensionItemRequestBuilderPatchRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/messageItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/messages/item/messageItemRequestBuilder.ts
@@ -1,6 +1,6 @@
 import {createMessageFromDiscriminatorValue} from '../../../../models/createMessageFromDiscriminatorValue';
 import {deserializeIntoMessage} from '../../../../models/deserializeIntoMessage';
-import {Message} from '../../../../models/message';
+import type {Message} from '../../../../models/message';
 import {serializeMessage} from '../../../../models/serializeMessage';
 import {AttachmentsRequestBuilder} from './attachments/attachmentsRequestBuilder';
 import {ExtensionsRequestBuilder} from './extensions/extensionsRequestBuilder';
@@ -8,7 +8,8 @@ import {MessageItemRequestBuilderDeleteRequestConfiguration} from './messageItem
 import {MessageItemRequestBuilderGetRequestConfiguration} from './messageItemRequestBuilderGetRequestConfiguration';
 import {MessageItemRequestBuilderPatchRequestConfiguration} from './messageItemRequestBuilderPatchRequestConfiguration';
 import {ContentRequestBuilder} from './value/contentRequestBuilder';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/messages/{message-id}
@@ -44,7 +45,7 @@ export class MessageItemRequestBuilder extends BaseRequestBuilder {
      * Delete a message in the specified user's mailbox, or delete a relationship of the message.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of ArrayBuffer
-     * @see {@link https://docs.microsoft.com/graph/api/message-delete?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/message-delete?view=graph-rest-1.0|Find more info here}
      */
     public delete(requestConfiguration?: MessageItemRequestBuilderDeleteRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
         const requestInfo = this.toDeleteRequestInformation(
@@ -56,7 +57,7 @@ export class MessageItemRequestBuilder extends BaseRequestBuilder {
      * The messages in a mailbox or folder. Read-only. Nullable.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Message
-     * @see {@link https://docs.microsoft.com/graph/api/opentypeextension-get?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/singlevaluelegacyextendedproperty-get?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: MessageItemRequestBuilderGetRequestConfiguration | undefined) : Promise<Message | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -69,10 +70,9 @@ export class MessageItemRequestBuilder extends BaseRequestBuilder {
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Message
-     * @see {@link https://docs.microsoft.com/graph/api/message-update?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/message-update?view=graph-rest-1.0|Find more info here}
      */
-    public patch(body: Message | undefined, requestConfiguration?: MessageItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<Message | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public patch(body: Message, requestConfiguration?: MessageItemRequestBuilderPatchRequestConfiguration | undefined) : Promise<Message | undefined> {
         const requestInfo = this.toPatchRequestInformation(
             body, requestConfiguration
         );
@@ -118,7 +118,7 @@ export class MessageItemRequestBuilder extends BaseRequestBuilder {
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPatchRequestInformation(body: Message | undefined, requestConfiguration?: MessageItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
+    public toPatchRequestInformation(body: Message, requestConfiguration?: MessageItemRequestBuilderPatchRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -129,7 +129,7 @@ export class MessageItemRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMessage);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMessage);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/messages/item/messageItemRequestBuilderDeleteRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/messageItemRequestBuilderDeleteRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageItemRequestBuilderDeleteRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/messageItemRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/messageItemRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {MessageItemRequestBuilderGetQueryParameters} from './messageItemRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageItemRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/messageItemRequestBuilderPatchRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/messageItemRequestBuilderPatchRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessageItemRequestBuilderPatchRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/value/contentRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/messages/item/value/contentRequestBuilder.ts
@@ -1,6 +1,7 @@
 import {ContentRequestBuilderGetRequestConfiguration} from './contentRequestBuilderGetRequestConfiguration';
 import {ContentRequestBuilderPutRequestConfiguration} from './contentRequestBuilderPutRequestConfiguration';
-import {BaseRequestBuilder, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/messages/{message-id}/$value
@@ -18,7 +19,7 @@ export class ContentRequestBuilder extends BaseRequestBuilder {
      * Get media content for the navigation property messages from users
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of ArrayBuffer
-     * @see {@link https://docs.microsoft.com/graph/api/opentypeextension-get?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/user-list-messages?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: ContentRequestBuilderGetRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -33,7 +34,6 @@ export class ContentRequestBuilder extends BaseRequestBuilder {
      * @returns a Promise of ArrayBuffer
      */
     public put(body: ArrayBuffer | undefined, requestConfiguration?: ContentRequestBuilderPutRequestConfiguration | undefined) : Promise<ArrayBuffer | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
         const requestInfo = this.toPutRequestInformation(
             body, requestConfiguration
         );

--- a/packages/test/generatedCode/users/item/messages/item/value/contentRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/value/contentRequestBuilderGetRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ContentRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/item/value/contentRequestBuilderPutRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/item/value/contentRequestBuilderPutRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface ContentRequestBuilderPutRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/messagesRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/messages/messagesRequestBuilder.ts
@@ -2,13 +2,14 @@ import {MessageCollectionResponse} from '../../../models/';
 import {createMessageCollectionResponseFromDiscriminatorValue} from '../../../models/createMessageCollectionResponseFromDiscriminatorValue';
 import {createMessageFromDiscriminatorValue} from '../../../models/createMessageFromDiscriminatorValue';
 import {deserializeIntoMessage} from '../../../models/deserializeIntoMessage';
-import {Message} from '../../../models/message';
+import type {Message} from '../../../models/message';
 import {serializeMessage} from '../../../models/serializeMessage';
 import {CountRequestBuilder} from './count/countRequestBuilder';
 import {MessageItemRequestBuilder} from './item/messageItemRequestBuilder';
 import {MessagesRequestBuilderGetRequestConfiguration} from './messagesRequestBuilderGetRequestConfiguration';
 import {MessagesRequestBuilderPostRequestConfiguration} from './messagesRequestBuilderPostRequestConfiguration';
-import {BaseRequestBuilder, getPathParameters, HttpMethod, Parsable, ParsableFactory, RequestAdapter, RequestInformation, RequestOption} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}/messages
@@ -22,7 +23,7 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
     }
     /**
      * Gets an item from the ApiSdk.users.item.messages.item collection
-     * @param messageId Unique identifier of the item
+     * @param messageId The unique identifier of message
      * @returns a MessageItemRequestBuilder
      */
     public byMessageId(messageId: string) : MessageItemRequestBuilder {
@@ -43,7 +44,7 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
      * The messages in a mailbox or folder. Read-only. Nullable.
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of MessageCollectionResponse
-     * @see {@link https://docs.microsoft.com/graph/api/opentypeextension-get?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/user-list-messages?view=graph-rest-1.0|Find more info here}
      */
     public get(requestConfiguration?: MessagesRequestBuilderGetRequestConfiguration | undefined) : Promise<MessageCollectionResponse | undefined> {
         const requestInfo = this.toGetRequestInformation(
@@ -52,14 +53,13 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
         return this.requestAdapter.sendAsync<MessageCollectionResponse>(requestInfo, createMessageCollectionResponseFromDiscriminatorValue, undefined);
     };
     /**
-     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. See known limitations of open extensions for more information. The table in the Permissions section lists the resources that support open extensions.
+     * Create a draft of a new message in either JSON or MIME format. When using JSON format, you can:- Include an attachment to the message.- Update the draft later to add content to the body or change other message properties. When using MIME format:- Provide the applicable Internet message headers and the MIME content, all encoded in base64 format in the request body.- /* Add any attachments and S/MIME properties to the MIME content. By default, this operation saves the draft in the Drafts folder. Send the draft message in a subsequent operation. Alternatively, send a new message in a single operation, or create a draft to forward, reply and reply-all to an existing message.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a Promise of Message
-     * @see {@link https://docs.microsoft.com/graph/api/opentypeextension-post-opentypeextension?view=graph-rest-1.0|Find more info here}
+     * @see {@link https://learn.microsoft.com/graph/api/user-post-messages?view=graph-rest-1.0|Find more info here}
      */
-    public post(body: Message | undefined, requestConfiguration?: MessagesRequestBuilderPostRequestConfiguration | undefined) : Promise<Message | undefined> {
-        if(!body) throw new Error("body cannot be undefined");
+    public post(body: Message, requestConfiguration?: MessagesRequestBuilderPostRequestConfiguration | undefined) : Promise<Message | undefined> {
         const requestInfo = this.toPostRequestInformation(
             body, requestConfiguration
         );
@@ -84,12 +84,12 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
         return requestInfo;
     };
     /**
-     * Create an open extension (openTypeExtension object) and add custom properties in a new or existing instance of a resource. You can create an open extension in a resource instance and store custom data to it all in the same operation, except for specific resources. See known limitations of open extensions for more information. The table in the Permissions section lists the resources that support open extensions.
+     * Create a draft of a new message in either JSON or MIME format. When using JSON format, you can:- Include an attachment to the message.- Update the draft later to add content to the body or change other message properties. When using MIME format:- Provide the applicable Internet message headers and the MIME content, all encoded in base64 format in the request body.- /* Add any attachments and S/MIME properties to the MIME content. By default, this operation saves the draft in the Drafts folder. Send the draft message in a subsequent operation. Alternatively, send a new message in a single operation, or create a draft to forward, reply and reply-all to an existing message.
      * @param body The request body
      * @param requestConfiguration Configuration for the request such as headers, query parameters, and middleware options.
      * @returns a RequestInformation
      */
-    public toPostRequestInformation(body: Message | undefined, requestConfiguration?: MessagesRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
+    public toPostRequestInformation(body: Message, requestConfiguration?: MessagesRequestBuilderPostRequestConfiguration | undefined) : RequestInformation {
         if(!body) throw new Error("body cannot be undefined");
         const requestInfo = new RequestInformation();
         requestInfo.urlTemplate = this.urlTemplate;
@@ -100,7 +100,7 @@ export class MessagesRequestBuilder extends BaseRequestBuilder {
             requestInfo.addRequestHeaders(requestConfiguration.headers);
             requestInfo.addRequestOptions(requestConfiguration.options);
         }
-        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body as any, serializeMessage);
+        requestInfo.setContentFromParsable(this.requestAdapter, "application/json", body, serializeMessage);
         return requestInfo;
     };
 }

--- a/packages/test/generatedCode/users/item/messages/messagesRequestBuilderGetRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/messagesRequestBuilderGetRequestConfiguration.ts
@@ -1,5 +1,5 @@
 import {MessagesRequestBuilderGetQueryParameters} from './messagesRequestBuilderGetQueryParameters';
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessagesRequestBuilderGetRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/messages/messagesRequestBuilderPostRequestConfiguration.ts
+++ b/packages/test/generatedCode/users/item/messages/messagesRequestBuilderPostRequestConfiguration.ts
@@ -1,4 +1,4 @@
-import {RequestOption} from '@microsoft/kiota-abstractions';
+import type {RequestOption} from '@microsoft/kiota-abstractions';
 
 export interface MessagesRequestBuilderPostRequestConfiguration {
     /**

--- a/packages/test/generatedCode/users/item/userItemRequestBuilder.ts
+++ b/packages/test/generatedCode/users/item/userItemRequestBuilder.ts
@@ -1,7 +1,8 @@
 import {InferenceClassificationRequestBuilder} from './inferenceClassification/inferenceClassificationRequestBuilder';
 import {MailFoldersRequestBuilder} from './mailFolders/mailFoldersRequestBuilder';
 import {MessagesRequestBuilder} from './messages/messagesRequestBuilder';
-import {BaseRequestBuilder, RequestAdapter} from '@microsoft/kiota-abstractions';
+import type {RequestAdapter} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users/{user-id}

--- a/packages/test/generatedCode/users/usersRequestBuilder.ts
+++ b/packages/test/generatedCode/users/usersRequestBuilder.ts
@@ -1,5 +1,6 @@
 import {UserItemRequestBuilder} from './item/userItemRequestBuilder';
-import {BaseRequestBuilder, getPathParameters, RequestAdapter} from '@microsoft/kiota-abstractions';
+import {BaseRequestBuilder, getPathParameters} from '@microsoft/kiota-abstractions';
+import type {RequestAdapter} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /users


### PR DESCRIPTION
Use ```import type``` whenever referencing the folowing interfaces:

``` javascript
interface ApiError 
interface RequestAdapter 
interface RequestOption
interface ResponseHandler
interface AccessTokenProvider
interface AuthenticationProvider
interface AdditionalDataHolder
interface Parsable
interface ParseNode
interface ParseNodeFactory
interface SerializationWriter
interface SerializationWriterFactory
interface BackedModel
interface BackingStore
interface BackingStoreFactory
interface ObservabilityOptions
interface Middleware 
interface ChaosHandlerOptions
interface TelemetryHandlerOptions
interface TestEntity
interface TestParser
```