### PR TITLE
Fixed: complex string serialization

### DIFF
--- a/packages/serialization/json/src/jsonSerializationWriter.ts
+++ b/packages/serialization/json/src/jsonSerializationWriter.ts
@@ -53,8 +53,11 @@ export class JsonSerializationWriter implements SerializationWriter {
   public writeDateOnlyValue = (key?: string, value?: DateOnly): void => this.writeStringValue(key, value?.toString());
   public writeTimeOnlyValue = (key?: string, value?: TimeOnly): void => this.writeStringValue(key, value?.toString());
   public writeDurationValue = (key?: string, value?: Duration): void => this.writeStringValue(key, value?.toString());
-  public writeNullValue = (key?: string): void => this.writeStringValue(key, `null`);
-
+  public writeNullValue = (key?: string): void => {
+    key && this.writePropertyName(key);
+    this.writer.push(`null`);
+    key && this.writer.push(JsonSerializationWriter.propertySeparator);
+  };
   public writeCollectionOfPrimitiveValues = <T>(
     key?: string,
     values?: T[],

--- a/packages/serialization/json/src/jsonSerializationWriter.ts
+++ b/packages/serialization/json/src/jsonSerializationWriter.ts
@@ -43,7 +43,11 @@ export class JsonSerializationWriter implements SerializationWriter {
       isValuePresent &&
       this.writer.push(JsonSerializationWriter.propertySeparator);
   };
-  public writeNumberValue = (key?: string, value?: number): void => this.writeStringValue(key, value?.toString());
+  public writeNumberValue = (key?: string, value?: number): void => {
+    key && value && this.writePropertyName(key);
+    value && this.writer.push(`${value}`);
+    key && value && this.writer.push(JsonSerializationWriter.propertySeparator);
+  };
   public writeGuidValue = (key?: string, value?: Guid): void => {
     key && value && this.writePropertyName(key);
     value && this.writer.push(`"${value}"`);

--- a/packages/serialization/json/src/jsonSerializationWriter.ts
+++ b/packages/serialization/json/src/jsonSerializationWriter.ts
@@ -43,41 +43,18 @@ export class JsonSerializationWriter implements SerializationWriter {
       isValuePresent &&
       this.writer.push(JsonSerializationWriter.propertySeparator);
   };
-  public writeNumberValue = (key?: string, value?: number): void => {
-    key && value && this.writePropertyName(key);
-    value && this.writer.push(`${value}`);
-    key && value && this.writer.push(JsonSerializationWriter.propertySeparator);
-  };
+  public writeNumberValue = (key?: string, value?: number): void => this.writeStringValue(key, value?.toString());
   public writeGuidValue = (key?: string, value?: Guid): void => {
     key && value && this.writePropertyName(key);
     value && this.writer.push(`"${value}"`);
     key && value && this.writer.push(JsonSerializationWriter.propertySeparator);
   };
-  public writeDateValue = (key?: string, value?: Date): void => {
-    key && value && this.writePropertyName(key);
-    value && this.writer.push(`"${value.toISOString()}"`);
-    key && value && this.writer.push(JsonSerializationWriter.propertySeparator);
-  };
-  public writeDateOnlyValue = (key?: string, value?: DateOnly): void => {
-    key && value && this.writePropertyName(key);
-    value && this.writer.push(`"${value.toString()}"`);
-    key && value && this.writer.push(JsonSerializationWriter.propertySeparator);
-  };
-  public writeTimeOnlyValue = (key?: string, value?: TimeOnly): void => {
-    key && value && this.writePropertyName(key);
-    value && this.writer.push(`"${value.toString()}"`);
-    key && value && this.writer.push(JsonSerializationWriter.propertySeparator);
-  };
-  public writeDurationValue = (key?: string, value?: Duration): void => {
-    key && value && this.writePropertyName(key);
-    value && this.writer.push(`"${value.toString()}"`);
-    key && value && this.writer.push(JsonSerializationWriter.propertySeparator);
-  };
-  public writeNullValue = (key?: string): void => {
-    key && this.writePropertyName(key);
-    this.writer.push(`null`);
-    key && this.writer.push(JsonSerializationWriter.propertySeparator);
-  };
+  public writeDateValue = (key?: string, value?: Date): void => this.writeStringValue(key, value?.toISOString());
+  public writeDateOnlyValue = (key?: string, value?: DateOnly): void => this.writeStringValue(key, value?.toString());
+  public writeTimeOnlyValue = (key?: string, value?: TimeOnly): void => this.writeStringValue(key, value?.toString());
+  public writeDurationValue = (key?: string, value?: Duration): void => this.writeStringValue(key, value?.toString());
+  public writeNullValue = (key?: string): void => this.writeStringValue(key, `null`);
+
   public writeCollectionOfPrimitiveValues = <T>(
     key?: string,
     values?: T[],
@@ -136,7 +113,7 @@ export class JsonSerializationWriter implements SerializationWriter {
     if (
       this.writer.length > 0 &&
       this.writer[this.writer.length - 1] ===
-        JsonSerializationWriter.propertySeparator
+      JsonSerializationWriter.propertySeparator
     ) {
       //removing the last separator
       this.writer.pop();

--- a/packages/serialization/json/src/jsonSerializationWriter.ts
+++ b/packages/serialization/json/src/jsonSerializationWriter.ts
@@ -29,7 +29,7 @@ export class JsonSerializationWriter implements SerializationWriter {
     | undefined;
   public writeStringValue = (key?: string, value?: string): void => {
     key && value && this.writePropertyName(key);
-    value && this.writer.push(`"${value}"`);
+    value && this.writer.push(JSON.stringify(value));
     key && value && this.writer.push(JsonSerializationWriter.propertySeparator);
   };
   private writePropertyName = (key: string): void => {

--- a/packages/serialization/json/test/common/jsonSerializationWriter.ts
+++ b/packages/serialization/json/test/common/jsonSerializationWriter.ts
@@ -12,6 +12,7 @@ describe("JsonParseNode", () => {
     const inputObject: TestParser = {
       testCollection: ["2", "3"],
       testString: "test",
+      testComplexString: "A more \"complex\" string with \r\nlinebreaks and 'weird' characters",
       testObject: {
         additionalData: {
           testObjectName: "str",
@@ -24,6 +25,7 @@ describe("JsonParseNode", () => {
     const expectedObject: TestParser = {
       testCollection: ["2", "3"],
       testString: "test",
+      testComplexString: "A more \"complex\" string with \r\nlinebreaks and 'weird' characters",
       testObject: {
         testObjectName: "str",
         testObjectProp: {

--- a/packages/serialization/json/test/common/testEntity.ts
+++ b/packages/serialization/json/test/common/testEntity.ts
@@ -3,6 +3,7 @@ import { ParseNode, SerializationWriter } from "@microsoft/kiota-abstractions";
 export interface TestParser {
   testCollection?: string[] | undefined;
   testString?: string | undefined;
+  testComplexString?: string | undefined;
   testObject?: Record<string, unknown> | undefined;
   additionalData?: Record<string, unknown>;
 }
@@ -24,6 +25,9 @@ export function deserializeTestParser(
     testString: (n) => {
       testParser.testString = n.getStringValue();
     },
+    textComlexString: (n) => {
+      testParser.testComplexString = n.getStringValue();
+    }
   };
 }
 
@@ -42,6 +46,7 @@ export function serializeTestParser(
     entity.testCollection
   );
   writer.writeStringValue("testString", entity.testString);
+  writer.writeStringValue("testComplexString", entity.testComplexString);
 
   writer.writeObjectValue("testObject", entity.testObject, serializeTestObject);
   writer.writeAdditionalData(entity.additionalData);


### PR DESCRIPTION
Fixes: #804 

Uses native JSON stringify to serialize an input string to ensure all special characters are encoded/escaped, for example, line breaks, quotation marks, etc.

This allows the JSON serializer to create a valid JSON payload when a property has a complex string.

TODO:
Should we refactor, at this point, all `writeXValue` methods in this serializer to forward the call to the `writeStringValue`?