### PR TITLE
do not require https for local host in azure identity provider.

### DIFF
--- a/packages/abstractions/src/authentication/validateProtocol.ts
+++ b/packages/abstractions/src/authentication/validateProtocol.ts
@@ -15,7 +15,6 @@ export function isLocalhostUrl(urlString: string) {
         const url = new URL(urlString);
         return localhostStrings.has(url.hostname);
     } catch (e) {
-        console.error(e);
         return false;
     }
 }

--- a/packages/abstractions/src/authentication/validateProtocol.ts
+++ b/packages/abstractions/src/authentication/validateProtocol.ts
@@ -1,9 +1,21 @@
+const localhostStrings: Set<string> = new Set<string>(["localhost", "[::1]", "::1", "127.0.0.1"]);
+
 export function validateProtocol(url: string): void {
-    if(!url.toLocaleLowerCase().startsWith("https://") && !windowUrlStartsWithHttps()) {
+    if(!isLocalhostUrl(url) && !url.toLocaleLowerCase().startsWith("https://") && !windowUrlStartsWithHttps()) {
         throw new Error("Authentication scheme can only be used with https requests");
     }
 }
 function windowUrlStartsWithHttps(): boolean {
     // @ts-ignore
     return typeof window !== "undefined" && typeof window.location !== "undefined" && (window.location.protocol as string).toLowerCase() !== "https:";
+}
+
+export function isLocalhostUrl(urlString: string) {
+    try {
+        const url = new URL(urlString);
+        return localhostStrings.has(url.hostname);
+    } catch (e) {
+        console.error(e);
+        return false;
+    }
 }

--- a/packages/abstractions/test/common/authentication/validateProtocolTest.ts
+++ b/packages/abstractions/test/common/authentication/validateProtocolTest.ts
@@ -1,5 +1,4 @@
-import { validateProtocol, isLocalhostUrl } from '../../../src/authentication'; // replace with your actual module
-
+import { validateProtocol, isLocalhostUrl } from '../../../src/authentication';
 import { expect } from "chai";
 
 describe('validateProtocol', () => {
@@ -13,6 +12,7 @@ describe('validateProtocol', () => {
 
     it('should not throw an error for localhost URLs', () => {
         expect(() => validateProtocol('http://localhost')).to.not.throw();
+        expect(() => validateProtocol('HTTP://LOCALHOST')).to.not.throw();
         expect(() => validateProtocol('http://127.0.0.1')).to.not.throw();
         expect(() => validateProtocol('http://[::1]')).to.not.throw();
     });

--- a/packages/abstractions/test/common/authentication/validateProtocolTest.ts
+++ b/packages/abstractions/test/common/authentication/validateProtocolTest.ts
@@ -1,0 +1,35 @@
+import { validateProtocol, isLocalhostUrl } from '../../../src/authentication'; // replace with your actual module
+
+import { expect } from "chai";
+
+describe('validateProtocol', () => {
+    it('should throw an error for non-https and non-localhost URLs', () => {
+        expect(() => validateProtocol('http://example.com')).to.throw('Authentication scheme can only be used with https requests');
+    });
+
+    it('should not throw an error for https URLs', () => {
+        expect(() => validateProtocol('https://example.com')).to.not.throw();
+    });
+
+    it('should not throw an error for localhost URLs', () => {
+        expect(() => validateProtocol('http://localhost')).to.not.throw();
+        expect(() => validateProtocol('http://127.0.0.1')).to.not.throw();
+        expect(() => validateProtocol('http://[::1]')).to.not.throw();
+    });
+});
+
+describe('isLocalhostUrl', () => {
+    it('should return true for localhost URLs', () => {
+        expect(isLocalhostUrl('http://localhost')).to.be.true;
+        expect(isLocalhostUrl('http://127.0.0.1')).to.be.true;
+        expect(isLocalhostUrl('http://[::1]')).to.be.true;
+    });
+
+    it('should return false for non-localhost URLs', () => {
+        expect(isLocalhostUrl('https://example.com')).to.be.false;
+    });
+
+    it('should return false for invalid URLs', () => {
+        expect(isLocalhostUrl('not a url')).to.be.false;
+    });
+});


### PR DESCRIPTION
Fixes: https://github.com/microsoft/kiota-typescript/issues/889