### PR TITLE
allow empty query parameters to be set.

### DIFF
--- a/packages/abstractions/src/requestInformation.ts
+++ b/packages/abstractions/src/requestInformation.ts
@@ -67,7 +67,7 @@ export class RequestInformation {
     } else {
       const data = {} as { [key: string]: unknown };
       for (const key in this.queryParameters) {
-        if (this.queryParameters[key]) {
+        if (this.queryParameters[key] != null && this.queryParameters[key] !== undefined) {
           data[key] = this.queryParameters[key];
         }
       }
@@ -287,7 +287,7 @@ export class RequestInformation {
     q?: T,
     p?: Record<string, string>,
   ): void {
-    if (!q) return;
+    if (q === null || q === undefined) return;
     Object.entries(q).forEach(([k, v]) => {
       let key = k;
       if (p) {

--- a/packages/abstractions/src/requestInformation.ts
+++ b/packages/abstractions/src/requestInformation.ts
@@ -67,7 +67,7 @@ export class RequestInformation {
     } else {
       const data = {} as { [key: string]: unknown };
       for (const key in this.queryParameters) {
-        if (this.queryParameters[key] != null && this.queryParameters[key] !== undefined) {
+        if (this.queryParameters[key] !== null && this.queryParameters[key] !== undefined) {
           data[key] = this.queryParameters[key];
         }
       }

--- a/packages/abstractions/test/common/requestInformation.ts
+++ b/packages/abstractions/test/common/requestInformation.ts
@@ -89,15 +89,15 @@ describe("RequestInformation", () => {
     assert.equal(requestInformation.URL, "http://localhost/me");
   });
 
-  it("Does not set empty search query parameter", () => {
+  it("Allows empty search query parameter", () => {
     const requestInformation = new RequestInformation();
     requestInformation.pathParameters["baseurl"] = baseUrl;
-    requestInformation.urlTemplate = "http://localhost/me{?%24select}";
+    requestInformation.urlTemplate = "http://localhost/me{?%24search}";
     requestInformation.setQueryStringParametersFromRawObject<GetQueryParameters>(
-      { search: "" },
+      { search: ''},
       getQueryParameterMapper,
     );
-    assert.equal(requestInformation.URL, "http://localhost/me");
+    assert.equal(requestInformation.URL, "http://localhost/me?%24search=");
   });
 
   it("Sets enum value in query parameters", () => {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/kiota-typescript/issues/1017