### PR TITLE
RequestOptions implementations constructors should accept an interface instead of parameters

### DIFF
--- a/packages/http/fetch/src/middlewares/options/headersInspectionOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/headersInspectionOptions.ts
@@ -8,7 +8,15 @@ export const HeadersInspectionOptionsKey = "HeadersInspectionOptionsKey";
  * @property {boolean} [inspectResponseHeaders = false] - Whether to inspect response headers
  */
 export interface HeadersInspectionOptionsParams {
+	/**
+	 * @member
+	 * whether to inspect request headers
+	 */
 	inspectRequestHeaders?: boolean;
+	/**
+	 * @member
+	 * whether to inspect response headers
+	 */
 	inspectResponseHeaders?: boolean;
 }
 
@@ -43,15 +51,17 @@ export class HeadersInspectionOptions implements RequestOption {
 
 	/**
 	 * @public
-	 * Gets whether to inspect request headers
-	 * @returns whether to inspect request headers
+	 * @member
+	 * @default false
+	 * whether to inspect request headers
 	 */
 	public inspectRequestHeaders: boolean;
 
 	/**
 	 * @public
-	 * Gets whether to inspect response headers
-	 * @returns whether to inspect response headers
+	 * @member
+	 * @default false
+	 * whether to inspect response headers
 	 */
 	public inspectResponseHeaders: boolean;
 

--- a/packages/http/fetch/src/middlewares/options/headersInspectionOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/headersInspectionOptions.ts
@@ -1,5 +1,17 @@
 import { type RequestOption, Headers } from "@microsoft/kiota-abstractions";
 export const HeadersInspectionOptionsKey = "HeadersInspectionOptionsKey";
+
+/**
+ * @interface
+ * Signature to define the HeadersInspectionOptions constructor parameters
+ * @property {boolean} [inspectRequestHeaders = false] - Whether to inspect request headers
+ * @property {boolean} [inspectResponseHeaders = false] - Whether to inspect response headers
+ */
+export interface HeadersInspectionOptionsParams {
+	inspectRequestHeaders?: boolean;
+	inspectResponseHeaders?: boolean;
+}
+
 /**
  * @class
  * @implements RequestOption
@@ -18,6 +30,7 @@ export class HeadersInspectionOptions implements RequestOption {
 	public getRequestHeaders() {
 		return this.requestHeaders;
 	}
+
 	/**
 	 * @public
 	 * @getter
@@ -27,18 +40,33 @@ export class HeadersInspectionOptions implements RequestOption {
 	public getResponseHeaders() {
 		return this.responseHeaders;
 	}
+
+	/**
+	 * @public
+	 * Gets whether to inspect request headers
+	 * @returns whether to inspect request headers
+	 */
+	public inspectRequestHeaders: boolean;
+
+	/**
+	 * @public
+	 * Gets whether to inspect response headers
+	 * @returns whether to inspect response headers
+	 */
+	public inspectResponseHeaders: boolean;
+
 	/**
 	 * @public
 	 * @constructor
 	 * To create an instance of HeadersInspectionOptions
-	 * @param {boolean} [inspectRequestHeaders = false] - Whether to inspect request headers
-	 * @param {boolean} [inspectResponseHeaders = false] - Whether to inspect response headers
+	 * @param {HeadersInspectionOptionsParams} [options = {}] - The headers inspection options value
 	 * @returns An instance of HeadersInspectionOptions
 	 */
-	public constructor(
-		public inspectRequestHeaders = false,
-		public inspectResponseHeaders = false,
-	) {}
+	public constructor(options: HeadersInspectionOptionsParams = {} as HeadersInspectionOptionsParams) {
+		this.inspectRequestHeaders = options.inspectRequestHeaders ?? false;
+		this.inspectResponseHeaders = options.inspectResponseHeaders ?? false;
+	}
+
 	public getKey(): string {
 		return HeadersInspectionOptionsKey;
 	}

--- a/packages/http/fetch/src/middlewares/options/parametersNameDecodingOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/parametersNameDecodingOptions.ts
@@ -13,8 +13,30 @@ import type { RequestOption } from "@microsoft/kiota-abstractions";
 
 export const ParametersNameDecodingHandlerOptionsKey = "RetryHandlerOptionKey";
 
+/**
+ * @interface
+ * Signature to define the ParametersNameDecodingHandlerOptions constructor parameters
+ */
+export interface ParametersNameDecodingHandlerOptionsParams {
+	enable?: boolean;
+	charactersToDecode?: string[];
+}
+
 /** The ParametersNameDecodingOptions request class */
 export class ParametersNameDecodingHandlerOptions implements RequestOption {
+	/**
+	 * @public
+	 * Whether to decode the specified characters in the request query parameters names
+	 */
+	public enable: boolean;
+
+	/**
+	 * @public
+	 * The characters to decode
+	 * @remarks	These characters are decoded by default: [".", "-", "~", "$"]
+	 */
+	public charactersToDecode: string[];
+
 	getKey(): string {
 		return ParametersNameDecodingHandlerOptionsKey;
 	}
@@ -23,8 +45,12 @@ export class ParametersNameDecodingHandlerOptions implements RequestOption {
 	 * @public
 	 * @constructor
 	 * To create an instance of ParametersNameDecodingHandlerOptions
-	 * @param {boolean} [enable = true] - Whether to decode the specified characters in the request query parameters names
-	 * @param {string[]} [charactersToDecode = [".", "-", "~", "$"]] - The characters to decode
+	 * @param {ParametersNameDecodingHandlerOptionsParams} [options = {}] - The optional parameters
 	 */
-	public constructor(public enable = true, public charactersToDecode: string[] = [".", "-", "~", "$"]) {}
+	public constructor(
+		options: ParametersNameDecodingHandlerOptionsParams = {} as ParametersNameDecodingHandlerOptionsParams,
+	  ) {
+		this.enable = options.enable ?? true;
+		this.charactersToDecode = options.charactersToDecode ?? [".", "-", "~", "$"];
+	  }
 }

--- a/packages/http/fetch/src/middlewares/options/parametersNameDecodingOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/parametersNameDecodingOptions.ts
@@ -18,7 +18,17 @@ export const ParametersNameDecodingHandlerOptionsKey = "RetryHandlerOptionKey";
  * Signature to define the ParametersNameDecodingHandlerOptions constructor parameters
  */
 export interface ParametersNameDecodingHandlerOptionsParams {
+	/**
+	 * @member
+	 * Whether to decode the specified characters in the request query parameters names
+	 * * @default true
+	 */
 	enable?: boolean;
+	/**
+	 * @member
+	 * The characters to decode
+	 * @default [".", "-", "~", "$"]
+	 */
 	charactersToDecode?: string[];
 }
 
@@ -33,7 +43,7 @@ export class ParametersNameDecodingHandlerOptions implements RequestOption {
 	/**
 	 * @public
 	 * The characters to decode
-	 * @remarks	These characters are decoded by default: [".", "-", "~", "$"]
+	 * @default [".", "-", "~", "$"]
 	 */
 	public charactersToDecode: string[];
 

--- a/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
@@ -66,24 +66,23 @@ export class RedirectHandlerOptions implements RequestOption {
 	 * @public
 	 * @constructor
 	 * To create an instance of RedirectHandlerOptions
-	 * @param {number} [maxRedirects = RedirectHandlerOptions.DEFAULT_MAX_REDIRECTS] - The max redirects value
-	 * @param {ShouldRedirect} [shouldRedirect = RedirectHandlerOptions.DEFAULT_SHOULD_RETRY] - The should redirect callback
+	 * @param {RedirectHandlerOptionsParams} [options = {}] - The redirect handler options instance
 	 * @returns An instance of RedirectHandlerOptions
 	 */
-	public constructor(public maxRedirects: number = RedirectHandlerOptions.DEFAULT_MAX_REDIRECTS, public shouldRedirect: ShouldRedirect = RedirectHandlerOptions.defaultShouldRetry) {
-		if (maxRedirects > RedirectHandlerOptions.MAX_MAX_REDIRECTS) {
-			const error = new Error(`MaxRedirects should not be more than ${RedirectHandlerOptions.MAX_MAX_REDIRECTS}`);
-			error.name = "MaxLimitExceeded";
-			throw error;
+	public constructor(options: RedirectHandlerOptionsParams = {} as RedirectHandlerOptionsParams) {
+		if (options.maxRedirects && options.maxRedirects > RedirectHandlerOptions.MAX_MAX_REDIRECTS) {
+		  const error = new Error(`MaxRedirects should not be more than ${RedirectHandlerOptions.MAX_MAX_REDIRECTS}`);
+		  error.name = "MaxLimitExceeded";
+		  throw error;
 		}
-		if (maxRedirects < 0) {
-			const error = new Error(`MaxRedirects should not be negative`);
-			error.name = "MinExpectationNotMet";
-			throw error;
+		if (options.maxRedirects && options.maxRedirects < 0) {
+		  const error = new Error(`MaxRedirects should not be negative`);
+		  error.name = "MinExpectationNotMet";
+		  throw error;
 		}
-		this.maxRedirects = maxRedirects;
-		this.shouldRedirect = shouldRedirect;
-	}
+		this.maxRedirects = options.maxRedirects || RedirectHandlerOptions.DEFAULT_MAX_REDIRECTS;
+		this.shouldRedirect = options.shouldRedirect || RedirectHandlerOptions.defaultShouldRetry;
+	  }
 
 	public getKey(): string {
 		return RedirectHandlerOptionKey;

--- a/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
@@ -18,6 +18,12 @@ import type { RequestOption } from "@microsoft/kiota-abstractions";
 export type ShouldRedirect = (response: Response) => boolean;
 
 export const RedirectHandlerOptionKey = "RedirectHandlerOption";
+
+export interface RedirectHandlerOptionsParams {
+	maxRedirects?: number;
+	shouldRedirect?: ShouldRedirect;
+}
+
 /**
  * @class
  * @implements MiddlewareOptions
@@ -43,6 +49,18 @@ export class RedirectHandlerOptions implements RequestOption {
 	 * A member holding default shouldRedirect callback
 	 */
 	private static defaultShouldRetry: ShouldRedirect = () => true;
+
+	/**
+	 * @public
+	 * A member holding the max redirects value
+	 */
+	public maxRedirects: number;
+    
+	/**
+	 * @public
+	 * A member holding the should redirect callback
+	 */
+  	public shouldRedirect: ShouldRedirect;
 
 	/**
 	 * @public

--- a/packages/http/fetch/src/middlewares/options/retryHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/retryHandlerOptions.ts
@@ -20,6 +20,27 @@ import type { FetchResponse } from "../../utils/fetchDefinitions";
 export type ShouldRetry = (delay: number, attempt: number, request: string, options: RequestInit | undefined, response: FetchResponse) => boolean;
 
 export const RetryHandlerOptionKey = "RetryHandlerOptionKey";
+/**
+ * @interface
+ * Signature to define the RetryHandlerOptions constructor parameters
+ */
+export interface RetryHandlerOptionsParams {
+	/**
+	 * @member
+	 * The delay value in seconds
+	 */
+	delay?: number;
+	/**
+	 * @member
+	 * The maxRetries value
+	 */
+	maxRetries?: number;
+	/**
+	 * @member
+	 * The shouldRetry callback function
+	 */
+	shouldRetry?: ShouldRetry;
+}
 
 /**
  * @class
@@ -63,44 +84,60 @@ export class RetryHandlerOptions implements RequestOption {
 	 */
 	private static defaultShouldRetry: ShouldRetry = () => true;
 
+	/*
+	 * @public
+	 * A member holding delay value in seconds
+	 */
+	public delay: number;
+
+	/**
+	 * @public
+	 * A member holding maxRetries value
+	 */
+	public maxRetries: number;
+
+	/**
+	 * @public
+	 * A member holding shouldRetry callback
+	 */
+	public shouldRetry: ShouldRetry;
+
 	/**
 	 * @public
 	 * @constructor
 	 * To create an instance of RetryHandlerOptions
-	 * @param {number} [delay = RetryHandlerOptions.DEFAULT_DELAY] - The delay value in seconds
-	 * @param {number} [maxRetries = RetryHandlerOptions.DEFAULT_MAX_RETRIES] - The maxRetries value
-	 * @param {ShouldRetry} [shouldRetry = RetryHandlerOptions.DEFAULT_SHOULD_RETRY] - The shouldRetry callback function
+	 * @param {RetryHandlerOptionsParams} options - The RetryHandlerOptionsParams object
 	 * @returns An instance of RetryHandlerOptions
 	 */
-	public constructor(public delay: number = RetryHandlerOptions.DEFAULT_DELAY, public maxRetries: number = RetryHandlerOptions.DEFAULT_MAX_RETRIES, public shouldRetry: ShouldRetry = RetryHandlerOptions.defaultShouldRetry) {
-		if (delay > RetryHandlerOptions.MAX_DELAY && maxRetries > RetryHandlerOptions.MAX_MAX_RETRIES) {
-			const error = new Error(`Delay and MaxRetries should not be more than ${RetryHandlerOptions.MAX_DELAY} and ${RetryHandlerOptions.MAX_MAX_RETRIES}`);
-			error.name = "MaxLimitExceeded";
-			throw error;
-		} else if (delay > RetryHandlerOptions.MAX_DELAY) {
-			const error = new Error(`Delay should not be more than ${RetryHandlerOptions.MAX_DELAY}`);
-			error.name = "MaxLimitExceeded";
-			throw error;
-		} else if (maxRetries > RetryHandlerOptions.MAX_MAX_RETRIES) {
-			const error = new Error(`MaxRetries should not be more than ${RetryHandlerOptions.MAX_MAX_RETRIES}`);
-			error.name = "MaxLimitExceeded";
-			throw error;
-		} else if (delay < 0 && maxRetries < 0) {
-			const error = new Error(`Delay and MaxRetries should not be negative`);
-			error.name = "MinExpectationNotMet";
-			throw error;
-		} else if (delay < 0) {
-			const error = new Error(`Delay should not be negative`);
-			error.name = "MinExpectationNotMet";
-			throw error;
-		} else if (maxRetries < 0) {
-			const error = new Error(`MaxRetries should not be negative`);
-			error.name = "MinExpectationNotMet";
-			throw error;
+	public constructor(options: RetryHandlerOptionsParams = {} as RetryHandlerOptionsParams) {
+		if (options.delay && options.delay > RetryHandlerOptions.MAX_DELAY) {
+			throw this.createError(`Delay should not be more than ${RetryHandlerOptions.MAX_DELAY}`, "MaxLimitExceeded");
 		}
-		this.delay = Math.min(delay, RetryHandlerOptions.MAX_DELAY);
-		this.maxRetries = Math.min(maxRetries, RetryHandlerOptions.MAX_MAX_RETRIES);
-		this.shouldRetry = shouldRetry;
+		if (options.maxRetries && options.maxRetries > RetryHandlerOptions.MAX_MAX_RETRIES) {
+			throw this.createError(`MaxRetries should not be more than ${RetryHandlerOptions.MAX_MAX_RETRIES}`, "MaxLimitExceeded");
+		}
+		if (options.delay && options.delay < 0) {
+			throw this.createError(`Delay should not be negative`, "MinExpectationNotMet");
+		}
+		if (options.maxRetries && options.maxRetries < 0) {
+			throw this.createError(`MaxRetries should not be negative`, "MinExpectationNotMet");
+		}
+		this.delay = Math.min(options.delay || RetryHandlerOptions.DEFAULT_DELAY, RetryHandlerOptions.MAX_DELAY);
+		this.maxRetries = Math.min(options.maxRetries || RetryHandlerOptions.DEFAULT_MAX_RETRIES, RetryHandlerOptions.MAX_MAX_RETRIES);
+		this.shouldRetry = options.shouldRetry || RetryHandlerOptions.defaultShouldRetry;
+	}
+
+	/**
+	 * @private
+	 * Creates an error object with a message and name
+	 * @param {string} message - The error message
+	 * @param {string} name - The error name
+	 * @returns An error object
+	 */
+	private createError(message: string, name: string): Error {
+		const error = new Error(message);
+		error.name = name;
+		return error;
 	}
 
 	/**

--- a/packages/http/fetch/src/middlewares/options/userAgentHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/userAgentHandlerOptions.ts
@@ -10,18 +10,73 @@ import type { RequestOption } from "@microsoft/kiota-abstractions";
 import { libraryVersion } from "./version";
 export const UserAgentHandlerOptionsKey = "UserAgentHandlerOptionKey";
 
+/**
+ * @interface
+ * Signature to define the user agent handler options
+ * @property {boolean} [enable = true] - Whether to add the user agent header to the request
+ * @property {string} [productName = "kiota-typescript"] - The product name to be added to the user agent header
+ * @property {string} [productVersion = "1.0.0-preview.12"] - The product version to be added to the user agent header
+ */
+/**
+ * Represents the options for the UserAgentHandler.
+ */
+export interface UserAgentHandlerOptionsParams {
+	/**
+	 * @member
+	 * @default true
+	 * Specifies whether to add the user agent header to the request
+	 */
+	enable?: boolean;
+	/**
+	 * @member
+	 * @default "kiota-typescript"
+	 * The product name to be added to the user agent header
+	 */
+	productName?: string;
+	/**
+	 * @member
+	 * @default "1.0.0-preview.12"
+	 * The product version to be added to the user agent header
+	 */
+	productVersion?: string;
+}
+
+/**
+ * Represents the options for the UserAgentHandler.
+ */
 export class UserAgentHandlerOptions implements RequestOption {
+	/**
+	 * @member
+	 * Specifies whether to add the user agent header to the request
+	 */
+	public enable: boolean;
+
+	/**
+	 * @member
+	 * @default "kiota-typescript"
+	 * The product name to be added to the user agent header
+	 */
+  	public productName: string;
+
+	/**
+	 * @member
+	 * The product version to be added to the user agent header
+	 */
+  	public productVersion: string;
+
 	getKey(): string {
 		return UserAgentHandlerOptionsKey;
 	}
-	
+
 	/**
 	 * @public
 	 * @constructor
-	 * To create an instance of UserAgentHandlerOption
-	 * @param {boolean} [enable = true] - Whether to add the user agent header to the request
-	 * @param {string} [productName = "kiota-typescript"] - The product name to be added to the user agent header
-	 * @param {string} [productVersion = "1.0.0-preview.12"] - The product version to be added to the user agent header
+	 * To create an instance of UserAgentHandlerOptions
+	 * @param {UserAgentHandlerOptionsParams} [options = {}] - The options for the UserAgentHandler
 	 */
-	public constructor(public enable = true, public productName = "kiota-typescript", public productVersion: string = libraryVersion) {}
+	public constructor(options: UserAgentHandlerOptionsParams = {} as UserAgentHandlerOptionsParams) {
+		this.enable = options.enable ?? true;
+		this.productName = options.productName || "kiota-typescript";
+		this.productVersion = options.productVersion || libraryVersion;
+	}
 }

--- a/packages/http/fetch/src/middlewares/options/userAgentHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/userAgentHandlerOptions.ts
@@ -14,6 +14,7 @@ export class UserAgentHandlerOptions implements RequestOption {
 	getKey(): string {
 		return UserAgentHandlerOptionsKey;
 	}
+	
 	/**
 	 * @public
 	 * @constructor

--- a/packages/http/fetch/test/common/middleware/headersInspectionHandler.ts
+++ b/packages/http/fetch/test/common/middleware/headersInspectionHandler.ts
@@ -25,7 +25,7 @@ describe("HeadersInspectionHandler.ts", () => {
 	});
 	describe("gets request headers", () => {
 		it("Should return request headers", async () => {
-			const options = new HeadersInspectionOptions(true);
+			const options = new HeadersInspectionOptions({inspectRequestHeaders: true});
 			const handler = new HeadersInspectionHandler(options);
 			const dummyFetchHandler = new DummyFetchHandler();
 			dummyFetchHandler.setResponses([
@@ -44,7 +44,7 @@ describe("HeadersInspectionHandler.ts", () => {
 			assert.equal(headers.tryGetValue("test")![0], "test");
 		});
 		it("Should return response headers", async () => {
-			const options = new HeadersInspectionOptions(false, true);
+			const options = new HeadersInspectionOptions({ inspectRequestHeaders: false, inspectResponseHeaders: true });
 			const handler = new HeadersInspectionHandler(options);
 			const dummyFetchHandler = new DummyFetchHandler();
 			dummyFetchHandler.setResponses([

--- a/packages/http/fetch/test/common/middleware/retryHandler.ts
+++ b/packages/http/fetch/test/common/middleware/retryHandler.ts
@@ -162,7 +162,7 @@ describe("RetryHandler.ts", function () {
 			const delay = 1;
 			const maxRetries = 2;
 			const shouldRetry: ShouldRetry = () => false;
-			const options = new RetryHandlerOptions(delay, maxRetries, shouldRetry);
+			const options = new RetryHandlerOptions({delay, maxRetries, shouldRetry});
 
 			const requestUrl = "url";
 			const fetchRequestInit = {
@@ -230,7 +230,7 @@ describe("RetryHandler.ts", function () {
 		});
 
 		it("Should successfully retry and return ok response", async () => {
-			const opts = new RetryHandlerOptions(1);
+			const opts = new RetryHandlerOptions({delay: 1});
 			const handler = new RetryHandler(opts);
 			handler.next = dummyFetchHandler;
 			dummyFetchHandler.setResponses([new Response(null, { status: 429 }), new Response(null, { status: 429 }), new Response("ok", { status: 200 })]);
@@ -239,7 +239,7 @@ describe("RetryHandler.ts", function () {
 		});
 
 		it("Should fail by exceeding max retries", async () => {
-			const opts = new RetryHandlerOptions(1, 2);
+			const opts = new RetryHandlerOptions({delay: 1, maxRetries: 2});
 			const handler = new RetryHandler(opts);
 			handler.next = dummyFetchHandler;
 			dummyFetchHandler.setResponses([new Response(null, { status: 429 }), new Response(null, { status: 429 }), new Response(null, { status: 429 }), new Response("ok", { status: 200 })]);

--- a/packages/http/fetch/test/common/middleware/retryHandlerOptions.ts
+++ b/packages/http/fetch/test/common/middleware/retryHandlerOptions.ts
@@ -20,7 +20,7 @@ describe("RetryHandlerOptions.ts", () => {
 
 		it("Should throw error for both delay and maxRetries are higher than the limit", () => {
 			try {
-				const options = new RetryHandlerOptions(1000, 1000);
+				const options = new RetryHandlerOptions({ delay: 1000, maxRetries: 1000});
 				throw new Error("Test Failed - Something wrong with the delay and maxRetries max limit validation");
 			} catch (error) {
 				assert.equal((error as Error).name, "MaxLimitExceeded");
@@ -29,7 +29,7 @@ describe("RetryHandlerOptions.ts", () => {
 
 		it("Should throw error for delay is higher than the limit", () => {
 			try {
-				const options = new RetryHandlerOptions(1000, 2);
+				const options = new RetryHandlerOptions({delay: 1000, maxRetries: 2});
 				throw new Error("Test Failed - Test Failed - Something wrong with the delay max limit validation");
 			} catch (error) {
 				assert.equal((error as Error).name, "MaxLimitExceeded");
@@ -38,7 +38,7 @@ describe("RetryHandlerOptions.ts", () => {
 
 		it("Should throw error for maxRetries is higher than the limit", () => {
 			try {
-				const options = new RetryHandlerOptions(1, 2000);
+				const options = new RetryHandlerOptions({delay: 1, maxRetries: 2000});
 				throw new Error("Test Failed - Something wrong with the maxRetries max limit validation");
 			} catch (error) {
 				assert.equal((error as Error).name, "MaxLimitExceeded");
@@ -47,7 +47,7 @@ describe("RetryHandlerOptions.ts", () => {
 
 		it("Should throw error for both delay and maxRetries are negative", () => {
 			try {
-				const options = new RetryHandlerOptions(-1, -100);
+				const options = new RetryHandlerOptions({delay: -1, maxRetries: -100});
 				throw new Error("Test Failed - Something wrong with the delay and maxRetries max limit validation");
 			} catch (error) {
 				assert.equal((error as Error).name, "MinExpectationNotMet");
@@ -57,7 +57,7 @@ describe("RetryHandlerOptions.ts", () => {
 		it("Should throw error for delay is negative", () => {
 			try {
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
-				const options = new RetryHandlerOptions(-5, 2);
+				const options = new RetryHandlerOptions({delay: -5, maxRetries: 2});
 				throw new Error("Test Failed - Something wrong with the delay max limit validation");
 			} catch (error) {
 				assert.equal((error as Error).name, "MinExpectationNotMet");
@@ -66,7 +66,7 @@ describe("RetryHandlerOptions.ts", () => {
 
 		it("Should throw error for maxRetries is negative", () => {
 			try {
-				const options = new RetryHandlerOptions(1, -10);
+				const options = new RetryHandlerOptions({delay: 1, maxRetries: -10});
 				throw new Error("Test Failed - Something wrong with the maxRetries max limit validation");
 			} catch (error) {
 				assert.equal((error as Error).name, "MinExpectationNotMet");
@@ -79,7 +79,7 @@ describe("RetryHandlerOptions.ts", () => {
 			const shouldRetry: ShouldRetry = (d, a, req, o, res) => {
 				return false;
 			};
-			const options = new RetryHandlerOptions(delay, maxRetries, shouldRetry);
+			const options = new RetryHandlerOptions({delay, maxRetries, shouldRetry});
 			assert.equal(options.delay, delay);
 			assert.equal(options.maxRetries, maxRetries);
 			assert.equal(options.shouldRetry, shouldRetry);

--- a/packages/http/fetch/test/common/middleware/userAgentHandler.ts
+++ b/packages/http/fetch/test/common/middleware/userAgentHandler.ts
@@ -38,7 +38,7 @@ describe("userAgentHandler.ts", function () {
 			assert.equal(((fetchRequestInit as any).headers["User-Agent"] as string).split("kiota-typescript").length, 2);
 		});
 		it("Does not add the product when disabled", async () => {
-			const options = new UserAgentHandlerOptions(false);
+			const options = new UserAgentHandlerOptions({ enable: false });
 			const handler = new UserAgentHandler(options);
 			handler.next = dummyFetchHandler;
 			dummyFetchHandler.setResponses([new Response("ok", { status: 200 })]);

--- a/packages/http/fetch/test/node/RedirectHandler.ts
+++ b/packages/http/fetch/test/node/RedirectHandler.ts
@@ -168,7 +168,7 @@ describe("RedirectHandler.ts", () => {
 			handler.next = dummyFetchHandler;
 			const maxRedirects = 2;
 			const shouldRedirect = () => true;
-			const options = new RedirectHandlerOptions(maxRedirects, shouldRedirect);
+			const options = new RedirectHandlerOptions({ maxRedirects: maxRedirects, shouldRedirect: shouldRedirect });
 
 			const requestUrl = "url";
 			const fetchRequestInit = {
@@ -247,7 +247,7 @@ describe("RedirectHandler.ts", () => {
 
 		it("Should not redirect for the redirect count equal to maxRedirects", async () => {
 			const maxRedirect = 1;
-			const options = new RedirectHandlerOptions(maxRedirect);
+			const options = new RedirectHandlerOptions({ maxRedirects: maxRedirect });
 			const handler = new RedirectHandler(options);
 			handler.next = dummyFetchHandler;
 			dummyFetchHandler.setResponses([new Response("", { status: 301 }), new Response("ok", { status: 200 }) as any]);
@@ -271,7 +271,7 @@ describe("RedirectHandler.ts", () => {
 		});
 
 		it("Should not redirect for shouldRedirect callback returning false", async () => {
-			const options = new RedirectHandlerOptions(undefined, () => false);
+			const options = new RedirectHandlerOptions({maxRedirects: undefined, shouldRedirect: () => false });
 			const handler = new RedirectHandler(options);
 			handler.next = dummyFetchHandler;
 			dummyFetchHandler.setResponses([new Response("", { status: 301 }), new Response("ok", { status: 200 }) as any]);

--- a/packages/http/fetch/test/node/RedirectHandlerOptions.ts
+++ b/packages/http/fetch/test/node/RedirectHandlerOptions.ts
@@ -19,7 +19,7 @@ describe("RedirectHandlerOptions.ts", () => {
 				return false;
 			};
 			const maxRedirects = 5;
-			const options = new RedirectHandlerOptions(maxRedirects, shouldRedirect);
+			const options = new RedirectHandlerOptions({ maxRedirects, shouldRedirect });
 			assert.equal(options.maxRedirects, maxRedirects);
 			assert.equal(options.shouldRedirect, shouldRedirect);
 		});
@@ -27,7 +27,7 @@ describe("RedirectHandlerOptions.ts", () => {
 		it("Should throw error for setting max redirects more than allowed", () => {
 			try {
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
-				const options = new RedirectHandlerOptions(100);
+				const options = new RedirectHandlerOptions({ maxRedirects: 100 });
 				throw new Error("Test Failed - Something wrong with the max redirects value redirection");
 			} catch (error) {
 				assert.equal((error as Error).name, "MaxLimitExceeded");
@@ -36,7 +36,7 @@ describe("RedirectHandlerOptions.ts", () => {
 		it("Should throw error for setting max redirects to negative", () => {
 			try {
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
-				const options = new RedirectHandlerOptions(-10);
+				const options = new RedirectHandlerOptions({ maxRedirects: -10 });
 				throw new Error(" Test Failed - Something wrong with the max redirects value redirection");
 			} catch (error) {
 				assert.equal((error as Error).name, "MinExpectationNotMet");


### PR DESCRIPTION
Fixes: https://github.com/microsoft/kiota-typescript/issues/467