### PR TITLE
skip null/undefined fields when serializing

### DIFF
--- a/packages/serialization/json/src/jsonSerializationWriter.ts
+++ b/packages/serialization/json/src/jsonSerializationWriter.ts
@@ -52,9 +52,10 @@ export class JsonSerializationWriter implements SerializationWriter {
       this.writer.push(JsonSerializationWriter.propertySeparator);
   };
   public writeNumberValue = (key?: string, value?: number): void => {
-    key && value && this.writePropertyName(key);
-    value && this.writer.push(`${value}`);
-    key && value && this.writer.push(JsonSerializationWriter.propertySeparator);
+    const isValuePresent = value !== null && value !== undefined;
+    key && isValuePresent && this.writePropertyName(key);
+    isValuePresent && this.writer.push(`${value}`);
+    key && isValuePresent && this.writer.push(JsonSerializationWriter.propertySeparator);
   };
   public writeGuidValue = (key?: string, value?: Guid): void => {
     key && value && this.writePropertyName(key);

--- a/packages/serialization/json/test/common/testEntity.ts
+++ b/packages/serialization/json/test/common/testEntity.ts
@@ -5,12 +5,14 @@ const fakeBackingStore: BackingStore = {} as BackingStore;
 export interface TestParser {
   testCollection?: string[] | undefined;
   testString?: string | undefined;
+  testBoolean?: boolean | undefined;
   testComplexString?: string | undefined;
   testObject?: Record<string, unknown> | undefined;
   additionalData?: Record<string, unknown>;
   testDate?: Date | undefined;
   foos?: FooResponse[] | undefined;
   id?: string | undefined;
+  testNumber?: number | undefined;
 }
 export interface TestBackedModel extends TestParser, BackedModel {
   backingStoreEnabled?: boolean | undefined;
@@ -63,6 +65,9 @@ export function deserializeTestParser(
     testString: (n) => {
       testParser.testString = n.getStringValue();
     },
+    testBoolean: (n) => {
+      testParser.testBoolean = n.getBooleanValue();
+    },
     textComplexString: (n) => {
       testParser.testComplexString = n.getStringValue();
     },
@@ -71,6 +76,12 @@ export function deserializeTestParser(
     },
     foos: (n) => {
       testParser.foos = n.getCollectionOfObjectValues(createFooParserFromDiscriminatorValue);
+    },
+    id: (n) => {
+      testParser.id = n.getStringValue();
+    },
+    testNumber: (n) => {
+      testParser.testNumber = n.getNumberValue();
     }
   };
 }
@@ -99,6 +110,12 @@ export function deserializeTestBackedModel(
     },
     id: (n) => {
       testParser.id = n.getStringValue();
+    },
+    testBoolean: (n) => {
+      testParser.testBoolean = n.getBooleanValue();
+    },
+    testNumber: (n) => {
+      testParser.testNumber = n.getNumberValue();
     },
   };
 }
@@ -151,6 +168,8 @@ export function serializeTestParser(
   writer.writeStringValue("testComplexString", entity.testComplexString);
 
   writer.writeDateValue("testDate", entity.testDate);
+  writer.writeNumberValue("testNumber", entity.testNumber);
+  writer.writeBooleanValue("testBoolean", entity.testBoolean);
   writer.writeObjectValue("testObject", entity.testObject, serializeTestObject);
   writer.writeCollectionOfObjectValues("foos", entity.foos, serializeFoo);
   writer.writeAdditionalData(entity.additionalData);


### PR DESCRIPTION
Fixes: https://github.com/microsoft/kiota-typescript/issues/1079

- Remove [falsy](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) evaluation to avoid situations where numbers like `0` or `false` are mistaken for null/undefined 