### PR TITLE
fix: getting rid of unnecessary guid-typescript dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5811,11 +5811,6 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
-    "node_modules/guid-typescript": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
-      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="
-    },
     "node_modules/handlebars": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
@@ -13254,7 +13249,6 @@
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
         "@std-uritemplate/std-uritemplate": "^0.0.57",
-        "guid-typescript": "^1.0.9",
         "tinyduration": "^3.3.0",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
@@ -13589,7 +13583,6 @@
       "dependencies": {
         "@microsoft/kiota-abstractions": "^1.0.0-preview.50",
         "@opentelemetry/api": "^1.7.0",
-        "guid-typescript": "^1.0.9",
         "tslib": "^2.6.2"
       }
     },
@@ -13599,7 +13592,6 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/kiota-abstractions": "^1.0.0-preview.50",
-        "guid-typescript": "^1.0.9",
         "tslib": "^2.6.2"
       }
     },
@@ -13609,7 +13601,6 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/kiota-abstractions": "^1.0.0-preview.50",
-        "guid-typescript": "^1.0.9",
         "tslib": "^2.6.2"
       }
     },
@@ -13619,7 +13610,6 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/kiota-abstractions": "^1.0.0-preview.50",
-        "guid-typescript": "^1.0.9",
         "tslib": "^2.6.2"
       },
       "devDependencies": {
@@ -13632,7 +13622,6 @@
       "license": "MIT",
       "dependencies": {
         "@microsoft/kiota-abstractions": "^1.0.0-preview.50",
-        "guid-typescript": "^1.0.9",
         "tslib": "^2.6.2"
       }
     },

--- a/packages/abstractions/package.json
+++ b/packages/abstractions/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@opentelemetry/api": "^1.7.0",
     "@std-uritemplate/std-uritemplate": "^0.0.57",
-    "guid-typescript": "^1.0.9",
     "tinyduration": "^3.3.0",
     "tslib": "^2.6.2",
     "uuid": "^9.0.1"

--- a/packages/abstractions/src/multipartBody.ts
+++ b/packages/abstractions/src/multipartBody.ts
@@ -1,5 +1,3 @@
-import { Guid } from "guid-typescript";
-
 import type { RequestAdapter } from "./requestAdapter";
 import type {
   ModelSerializerFunction,
@@ -7,6 +5,7 @@ import type {
   ParseNode,
   SerializationWriter,
 } from "./serialization";
+import { createGuid } from "./utils/guidUtils";
 /**
  * Defines an interface for a multipart body for request or response.
  */
@@ -18,7 +17,7 @@ export class MultipartBody implements Parsable {
    * Instantiates a new MultipartBody.
    */
   public constructor() {
-    this._boundary = Guid.create().toString().replace(/-/g, "");
+    this._boundary = createGuid().replace(/-/g, "");
   }
   /**
    * Adds or replaces a part with the given name, content type and content.

--- a/packages/abstractions/src/serialization/parseNode.ts
+++ b/packages/abstractions/src/serialization/parseNode.ts
@@ -1,4 +1,4 @@
-import type { Guid } from "guid-typescript";
+import type { Guid } from "../utils/guidUtils";
 
 import type { DateOnly } from "../dateOnly";
 import type { Duration } from "../duration";

--- a/packages/abstractions/src/serialization/serializationWriter.ts
+++ b/packages/abstractions/src/serialization/serializationWriter.ts
@@ -1,4 +1,4 @@
-import type { Guid } from "guid-typescript";
+import type { Guid } from "../utils/guidUtils";
 
 import type { DateOnly } from "../dateOnly";
 import type { Duration } from "../duration";

--- a/packages/abstractions/src/utils/guidUtils.ts
+++ b/packages/abstractions/src/utils/guidUtils.ts
@@ -1,9 +1,14 @@
-import { Guid } from "guid-typescript";
+export type Guid = string
 
-export function parseGuidString(source?: string): Guid | undefined {
-  if (source && Guid.isGuid(source)) {
-    return Guid.parse(source);
-  } else {
-    return undefined;
+export function createGuid(): Guid {
+  return ([gen(2), gen(1), gen(1), gen(1), gen(3)].join("-"));
+}
+
+function gen(count: number) {
+  let out: string = "";
+  for (let i: number = 0; i < count; i++) {
+      // tslint:disable-next-line:no-bitwise
+      out += (((1 + Math.random()) * 0x10000) | 0).toString(16).substring(1);
   }
+  return out;
 }

--- a/packages/http/fetch/package.json
+++ b/packages/http/fetch/package.json
@@ -40,7 +40,6 @@
 	"dependencies": {
 		"@microsoft/kiota-abstractions": "^1.0.0-preview.50",
 		"@opentelemetry/api": "^1.7.0",
-		"guid-typescript": "^1.0.9",
 		"tslib": "^2.6.2"
 	},
 	"publishConfig": {

--- a/packages/http/fetch/test/common/mockParseNodeFactory.ts
+++ b/packages/http/fetch/test/common/mockParseNodeFactory.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import type { DateOnly, Duration, Parsable, ParsableFactory, ParseNode, ParseNodeFactory, TimeOnly } from "@microsoft/kiota-abstractions";
-import type { Guid } from "guid-typescript";
+import type { DateOnly, Duration, Guid, Parsable, ParsableFactory, ParseNode, ParseNodeFactory, TimeOnly } from "@microsoft/kiota-abstractions";
+
 
 export class MockParseNodeFactory implements ParseNodeFactory {
 	parseNodeValue: ParseNode;

--- a/packages/serialization/form/package.json
+++ b/packages/serialization/form/package.json
@@ -40,7 +40,6 @@
   "homepage": "https://github.com/microsoft/kiota-typescript#readme",
   "dependencies": {
     "@microsoft/kiota-abstractions": "^1.0.0-preview.50",
-    "guid-typescript": "^1.0.9",
     "tslib": "^2.6.2"
   },
   "publishConfig": {

--- a/packages/serialization/form/src/formSerializationWriter.ts
+++ b/packages/serialization/form/src/formSerializationWriter.ts
@@ -5,9 +5,9 @@ import {
   type ModelSerializerFunction,
   type Parsable,
   type SerializationWriter,
+  type Guid,
   TimeOnly,
 } from "@microsoft/kiota-abstractions";
-import type { Guid } from "guid-typescript";
 
 export class FormSerializationWriter implements SerializationWriter {
   public writeByteArrayValue(

--- a/packages/serialization/json/package.json
+++ b/packages/serialization/json/package.json
@@ -40,7 +40,6 @@
   "homepage": "https://github.com/microsoft/kiota-typescript#readme",
   "dependencies": {
     "@microsoft/kiota-abstractions": "^1.0.0-preview.50",
-    "guid-typescript": "^1.0.9",
     "tslib": "^2.6.2"
   },
   "publishConfig": {

--- a/packages/serialization/json/src/jsonSerializationWriter.ts
+++ b/packages/serialization/json/src/jsonSerializationWriter.ts
@@ -2,6 +2,7 @@
 import {
   DateOnly,
   Duration,
+  type Guid,
   isUntypedNode,
   type ModelSerializerFunction,
   type Parsable,
@@ -15,7 +16,6 @@ import {
   isUntypedObject,
   isUntypedArray,
 } from "@microsoft/kiota-abstractions";
-import type { Guid } from "guid-typescript";
 
 export class JsonSerializationWriter implements SerializationWriter {
   public writeByteArrayValue(

--- a/packages/serialization/json/test/common/testEntity.ts
+++ b/packages/serialization/json/test/common/testEntity.ts
@@ -1,5 +1,4 @@
-import type { BackedModel, BackingStore, Parsable, ParseNode, SerializationWriter } from "@microsoft/kiota-abstractions";
-import { Guid } from "guid-typescript";
+import type { BackedModel, BackingStore, Guid, Parsable, ParseNode, SerializationWriter } from "@microsoft/kiota-abstractions";
 
 const fakeBackingStore: BackingStore = {} as BackingStore;
 

--- a/packages/serialization/multipart/package.json
+++ b/packages/serialization/multipart/package.json
@@ -36,7 +36,6 @@
   "homepage": "https://github.com/microsoft/kiota-typescript#readme",
   "dependencies": {
     "@microsoft/kiota-abstractions": "^1.0.0-preview.50",
-    "guid-typescript": "^1.0.9",
     "tslib": "^2.6.2"
   },
   "devDependencies": {

--- a/packages/serialization/multipart/src/multipartSerializationWriter.ts
+++ b/packages/serialization/multipart/src/multipartSerializationWriter.ts
@@ -2,12 +2,12 @@
 import {
   type DateOnly,
   type Duration,
+  type Guid,
   MultipartBody,
   type Parsable,
   type SerializationWriter,
   type ModelSerializerFunction,
   type TimeOnly } from "@microsoft/kiota-abstractions";
-import type { Guid } from "guid-typescript";
 
 /** Serialization writer for multipart/form-data */
 export class MultipartSerializationWriter implements SerializationWriter {

--- a/packages/serialization/text/package.json
+++ b/packages/serialization/text/package.json
@@ -40,7 +40,6 @@
   "homepage": "https://github.com/microsoft/kiota-typescript#readme",
   "dependencies": {
     "@microsoft/kiota-abstractions": "^1.0.0-preview.50",
-    "guid-typescript": "^1.0.9",
     "tslib": "^2.6.2"
   },
   "publishConfig": {

--- a/packages/serialization/text/src/textSerializationWriter.ts
+++ b/packages/serialization/text/src/textSerializationWriter.ts
@@ -2,12 +2,12 @@
 import type {
   DateOnly,
   Duration,
+  Guid,
   ModelSerializerFunction,
   Parsable,
   SerializationWriter,
   TimeOnly,
 } from "@microsoft/kiota-abstractions";
-import type { Guid } from "guid-typescript";
 
 export class TextSerializationWriter implements SerializationWriter {
   public writeByteArrayValue(


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota/issues/4508
Using a custom Guid type to get rid of unnecessary package (and partly broken) `guid-typescript`. 