### PR TITLE
fix: bumps versions for release

### DIFF
--- a/packages/abstractions/package.json
+++ b/packages/abstractions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-abstractions",
-	"version": "1.0.0-preview.62",
+	"version": "1.0.0-preview.63",
 	"description": "Core abstractions for kiota generated libraries in TypeScript and JavaScript",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/authentication/azure/package.json
+++ b/packages/authentication/azure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-authentication-azure",
-	"version": "1.0.0-preview.57",
+	"version": "1.0.0-preview.58",
 	"description": "Authentication provider for Kiota using Azure Identity",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/authentication/spfx/package.json
+++ b/packages/authentication/spfx/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-authentication-spfx",
-	"version": "1.0.0-preview.51",
+	"version": "1.0.0-preview.52",
 	"description": "Authentication provider for using Kiota in SPFx solutions",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-bundle",
-	"version": "1.0.0-preview.5",
+	"version": "1.0.0-preview.6",
 	"description": "Kiota Bundle package providing default implementations for client setup for kiota generated libraries in TypeScript and JavaScript",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/http/fetch/package.json
+++ b/packages/http/fetch/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-http-fetchlibrary",
-	"version": "1.0.0-preview.61",
+	"version": "1.0.0-preview.62",
 	"description": "Kiota request adapter implementation with fetch",
 	"keywords": [
 		"Kiota",

--- a/packages/serialization/form/package.json
+++ b/packages/serialization/form/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-serialization-form",
-	"version": "1.0.0-preview.50",
+	"version": "1.0.0-preview.51",
 	"description": "Implementation of Kiota Serialization interfaces for URI from encoded",
 	"main": "dist/es/src/index.js",
 	"browser": {

--- a/packages/serialization/json/package.json
+++ b/packages/serialization/json/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-serialization-json",
-	"version": "1.0.0-preview.62",
+	"version": "1.0.0-preview.63",
 	"description": "Implementation of Kiota Serialization interfaces for JSON",
 	"main": "dist/es/src/index.js",
 	"type": "module",

--- a/packages/serialization/multipart/package.json
+++ b/packages/serialization/multipart/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-serialization-multipart",
-	"version": "1.0.0-preview.40",
+	"version": "1.0.0-preview.41",
 	"description": "Implementation of Kiota Serialization interfaces for multipart form data",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/serialization/text/package.json
+++ b/packages/serialization/text/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-serialization-text",
-	"version": "1.0.0-preview.59",
+	"version": "1.0.0-preview.60",
 	"description": "Implementation of Kiota Serialization interfaces for text",
 	"main": "dist/es/src/index.js",
 	"browser": {


### PR DESCRIPTION
Follow up to https://github.com/microsoft/kiota-typescript/pull/1347

As highlighted in the comment below, the form package wasn't bumped and is causing issue.

https://github.com/microsoft/kiota-typescript/commit/d881b596d9b01f016e0e5825de02e41ccea5b32a#commitcomment-146214405