### PR TITLE
Allow falsy values as path parameters in URL

### DIFF
--- a/packages/abstractions/src/requestInformation.ts
+++ b/packages/abstractions/src/requestInformation.ts
@@ -68,7 +68,7 @@ export class RequestInformation implements RequestInformationSetContent {
 				}
 			}
 			for (const key in this.pathParameters) {
-				if (this.pathParameters[key]) {
+				if (this.pathParameters[key] !== null && this.pathParameters[key] !== undefined) {
 					data[key] = this.normalizeValue(this.pathParameters[key]);
 				}
 			}

--- a/packages/abstractions/test/common/requestInformation.ts
+++ b/packages/abstractions/test/common/requestInformation.ts
@@ -96,6 +96,30 @@ describe("RequestInformation", () => {
 		assert.equal(requestInformation.URL, "http://localhost/me?datasets=1,2");
 	});
 
+	it.each([
+		{ someNumber: -1, expected: "http://localhost/-1" },
+		{ someNumber: 0, expected: "http://localhost/0" },
+		{ someNumber: 1, expected: "http://localhost/1" },
+		{ someNumber: NaN, expected: "http://localhost/NaN" },
+	])("Sets number $someNumber in path parameters", () => {
+		const requestInformation = new RequestInformation();
+		requestInformation.pathParameters["baseurl"] = baseUrl;
+		requestInformation.pathParameters["someNumber"] = 0;
+		requestInformation.urlTemplate = "http://localhost/{someNumber}";
+		assert.equal(requestInformation.URL, "http://localhost/0");
+	});
+
+	it.each([
+		{ someBoolean: true, expected: "http://localhost/true" },
+		{ someBoolean: false, expected: "http://localhost/false" },
+	])("Sets false in path parameters", () => {
+		const requestInformation = new RequestInformation();
+		requestInformation.pathParameters["baseurl"] = baseUrl;
+		requestInformation.pathParameters["someBoolean"] = false;
+		requestInformation.urlTemplate = "http://localhost/{someBoolean}";
+		assert.equal(requestInformation.URL, "http://localhost/false");
+	});
+
 	it("Sets enum value in path parameters", () => {
 		const requestInformation = new RequestInformation();
 		requestInformation.pathParameters["baseurl"] = baseUrl;


### PR DESCRIPTION
This makes it possible to set falsy values as path parameters except `null` or `undefined`. Before this change, it was not possible to set `0` or `false` as path parameters because they were filtered out from the data passed to `StdUriTemplate.expand`.

Fixes #1357 