### PR TITLE
Fixes `serializeMultipartBody` function signature.

### DIFF
--- a/packages/abstractions/package.json
+++ b/packages/abstractions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-abstractions",
-	"version": "1.0.0-preview.66",
+	"version": "1.0.0-preview.67",
 	"description": "Core abstractions for kiota generated libraries in TypeScript and JavaScript",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/abstractions/src/multipartBody.ts
+++ b/packages/abstractions/src/multipartBody.ts
@@ -93,7 +93,7 @@ interface MultipartEntry {
 	serializationCallback?: ModelSerializerFunction<Parsable>;
 }
 
-export const serializeMultipartBody = (writer: SerializationWriter, multipartBody: Partial<MultipartBody> = new MultipartBody()): void => {
+export const serializeMultipartBody = (writer: SerializationWriter, multipartBody: Partial<MultipartBody> | undefined | null = new MultipartBody()): void => {
 	if (!writer) {
 		throw new Error("writer cannot be undefined");
 	}

--- a/packages/authentication/azure/package.json
+++ b/packages/authentication/azure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-authentication-azure",
-	"version": "1.0.0-preview.61",
+	"version": "1.0.0-preview.62",
 	"description": "Authentication provider for Kiota using Azure Identity",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/authentication/spfx/package.json
+++ b/packages/authentication/spfx/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-authentication-spfx",
-	"version": "1.0.0-preview.55",
+	"version": "1.0.0-preview.56",
 	"description": "Authentication provider for using Kiota in SPFx solutions",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-bundle",
-	"version": "1.0.0-preview.9",
+	"version": "1.0.0-preview.10",
 	"description": "Kiota Bundle package providing default implementations for client setup for kiota generated libraries in TypeScript and JavaScript",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/http/fetch/package.json
+++ b/packages/http/fetch/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-http-fetchlibrary",
-	"version": "1.0.0-preview.65",
+	"version": "1.0.0-preview.66",
 	"description": "Kiota request adapter implementation with fetch",
 	"keywords": [
 		"Kiota",

--- a/packages/serialization/form/package.json
+++ b/packages/serialization/form/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-serialization-form",
-	"version": "1.0.0-preview.54",
+	"version": "1.0.0-preview.55",
 	"description": "Implementation of Kiota Serialization interfaces for URI from encoded",
 	"main": "dist/es/src/index.js",
 	"browser": {

--- a/packages/serialization/json/package.json
+++ b/packages/serialization/json/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-serialization-json",
-	"version": "1.0.0-preview.66",
+	"version": "1.0.0-preview.67",
 	"description": "Implementation of Kiota Serialization interfaces for JSON",
 	"main": "dist/es/src/index.js",
 	"type": "module",

--- a/packages/serialization/multipart/package.json
+++ b/packages/serialization/multipart/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-serialization-multipart",
-	"version": "1.0.0-preview.44",
+	"version": "1.0.0-preview.45",
 	"description": "Implementation of Kiota Serialization interfaces for multipart form data",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/serialization/text/package.json
+++ b/packages/serialization/text/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-serialization-text",
-	"version": "1.0.0-preview.63",
+	"version": "1.0.0-preview.64",
 	"description": "Implementation of Kiota Serialization interfaces for text",
 	"main": "dist/es/src/index.js",
 	"browser": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "test-kiota-typescript-libraries",
 	"description": "Sample Project",
-	"version": "0.0.1-preview.8",
+	"version": "0.0.1-preview.9",
 	"main": "index.js",
 	"private": true,
 	"scripts": {


### PR DESCRIPTION
Related to https://github.com/microsoft/kiota/pull/5518

The `serializeMultipartBody` function does not match the `ModelSerializerFunction<Parsable>` type after updates made in https://github.com/microsoft/kiota-typescript/pull/1248
