### PR TITLE
fix: release please configuration tag alignment

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -7,6 +7,5 @@
   "packages/serialization/form": "1.0.0-preview.54",
   "packages/serialization/json": "1.0.0-preview.66",
   "packages/serialization/multipart": "1.0.0-preview.44",
-  "packages/serialization/text": "1.0.0-preview.63",
-  ".": "0.0.0"
+  "packages/serialization/text": "1.0.0-preview.63"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,11 +1,12 @@
 {
-  "packages/abstractions": "1.0.0-preview.64",
-  "packages/authentication/azure": "1.0.0-preview.59",
-  "packages/authentication/spfx": "1.0.0-preview.53",
-  "packages/bundle": "1.0.0-preview.7",
-  "packages/http/fetch": "1.0.0-preview.63",
-  "packages/serialization/form": "1.0.0-preview.52",
-  "packages/serialization/json": "1.0.0-preview.64",
-  "packages/serialization/multipart": "1.0.0-preview.42",
-  "packages/serialization/text": "1.0.0-preview.61"
+  "packages/abstractions": "1.0.0-preview.66",
+  "packages/authentication/azure": "1.0.0-preview.61",
+  "packages/authentication/spfx": "1.0.0-preview.55",
+  "packages/bundle": "1.0.0-preview.9",
+  "packages/http/fetch": "1.0.0-preview.65",
+  "packages/serialization/form": "1.0.0-preview.54",
+  "packages/serialization/json": "1.0.0-preview.66",
+  "packages/serialization/multipart": "1.0.0-preview.44",
+  "packages/serialization/text": "1.0.0-preview.63",
+  ".": "0.0.0"
 }

--- a/packages/abstractions/package.json
+++ b/packages/abstractions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-abstractions",
-	"version": "1.0.0-preview.67",
+	"version": "1.0.0-preview.66",
 	"description": "Core abstractions for kiota generated libraries in TypeScript and JavaScript",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/authentication/azure/package.json
+++ b/packages/authentication/azure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-authentication-azure",
-	"version": "1.0.0-preview.62",
+	"version": "1.0.0-preview.61",
 	"description": "Authentication provider for Kiota using Azure Identity",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/authentication/spfx/package.json
+++ b/packages/authentication/spfx/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-authentication-spfx",
-	"version": "1.0.0-preview.56",
+	"version": "1.0.0-preview.55",
 	"description": "Authentication provider for using Kiota in SPFx solutions",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-bundle",
-	"version": "1.0.0-preview.10",
+	"version": "1.0.0-preview.9",
 	"description": "Kiota Bundle package providing default implementations for client setup for kiota generated libraries in TypeScript and JavaScript",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/http/fetch/package.json
+++ b/packages/http/fetch/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-http-fetchlibrary",
-	"version": "1.0.0-preview.66",
+	"version": "1.0.0-preview.65",
 	"description": "Kiota request adapter implementation with fetch",
 	"keywords": [
 		"Kiota",

--- a/packages/serialization/form/package.json
+++ b/packages/serialization/form/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-serialization-form",
-	"version": "1.0.0-preview.55",
+	"version": "1.0.0-preview.54",
 	"description": "Implementation of Kiota Serialization interfaces for URI from encoded",
 	"main": "dist/es/src/index.js",
 	"browser": {

--- a/packages/serialization/json/package.json
+++ b/packages/serialization/json/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-serialization-json",
-	"version": "1.0.0-preview.67",
+	"version": "1.0.0-preview.66",
 	"description": "Implementation of Kiota Serialization interfaces for JSON",
 	"main": "dist/es/src/index.js",
 	"type": "module",

--- a/packages/serialization/multipart/package.json
+++ b/packages/serialization/multipart/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-serialization-multipart",
-	"version": "1.0.0-preview.45",
+	"version": "1.0.0-preview.44",
 	"description": "Implementation of Kiota Serialization interfaces for multipart form data",
 	"main": "dist/es/src/index.js",
 	"module": "dist/es/src/index.js",

--- a/packages/serialization/text/package.json
+++ b/packages/serialization/text/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@microsoft/kiota-serialization-text",
-	"version": "1.0.0-preview.64",
+	"version": "1.0.0-preview.63",
 	"description": "Implementation of Kiota Serialization interfaces for text",
 	"main": "dist/es/src/index.js",
 	"browser": {

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "test-kiota-typescript-libraries",
 	"description": "Sample Project",
-	"version": "0.0.1-preview.9",
+	"version": "0.0.1-preview.8",
 	"main": "index.js",
 	"private": true,
 	"scripts": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,68 +1,59 @@
 {
-  "exclude-paths": [
-    ".git",
-    ".idea",
-    ".github",
-    ".vscode"
-  ],
+  "exclude-paths": [".git", ".idea", ".github", ".vscode"],
   "include-component-in-tag": true,
-  "include-v-in-tag": true,
+  "include-v-in-tag": false,
+  "tag-separator": "@",
   "separate-pull-requests": false,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "versioning": "always-bump-minor",
+  "versioning": "prerelease",
   "packages": {
     "packages/abstractions": {
-      "name": "@microsoft/kiota-abstractions",
-      "path": "packages/abstractions",
+      "component": "@microsoft/kiota-abstractions",
       "release-type": "node",
       "changelog-path": "CHANGELOG.md"
     },
     "packages/authentication/azure": {
-      "name": "@microsoft/kiota-authentication-azure",
-      "path": "packages/authentication/azure",
+      "component": "@microsoft/kiota-authentication-azure",
       "release-type": "node",
       "changelog-path": "CHANGELOG.md"
     },
     "packages/authentication/spfx": {
-      "name": "@microsoft/kiota-authentication-spfx",
-      "path": "packages/authentication/spfx",
+      "component": "@microsoft/kiota-authentication-spfx",
       "release-type": "node",
       "changelog-path": "CHANGELOG.md"
     },
     "packages/bundle": {
-      "name": "@microsoft/kiota-bundle",
-      "path": "packages/bundle",
+      "component": "@microsoft/kiota-bundle",
       "release-type": "node",
       "changelog-path": "CHANGELOG.md"
     },
     "packages/http/fetch": {
-      "name": "@microsoft/kiota-http-fetchlibrary",
-      "path": "packages/http/fetch",
+      "component": "@microsoft/kiota-http-fetchlibrary",
       "release-type": "node",
       "changelog-path": "CHANGELOG.md"
     },
     "packages/serialization/form": {
-      "name": "@microsoft/kiota-serialization-form",
-      "path": "packages/serialization/form",
+      "component": "@microsoft/kiota-serialization-form",
       "release-type": "node",
       "changelog-path": "CHANGELOG.md"
     },
     "packages/serialization/json": {
-      "name": "@microsoft/kiota-serialization-json",
-      "path": "packages/serialization/json",
+      "component": "@microsoft/kiota-serialization-json",
       "release-type": "node",
       "changelog-path": "CHANGELOG.md"
     },
     "packages/serialization/multipart": {
-      "name": "@microsoft/kiota-serialization-multipart",
-      "path": "packages/serialization/multipart",
+      "component": "@microsoft/kiota-serialization-multipart",
       "release-type": "node",
       "changelog-path": "CHANGELOG.md"
     },
     "packages/serialization/text": {
-      "name": "@microsoft/kiota-serialization-text",
-      "path": "packages/serialization/text",
+      "component": "@microsoft/kiota-serialization-text",
+      "release-type": "node",
+      "changelog-path": "CHANGELOG.md"
+    },
+    ".": {
       "release-type": "node",
       "changelog-path": "CHANGELOG.md"
     }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -52,10 +52,6 @@
       "component": "@microsoft/kiota-serialization-text",
       "release-type": "node",
       "changelog-path": "CHANGELOG.md"
-    },
-    ".": {
-      "release-type": "node",
-      "changelog-path": "CHANGELOG.md"
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Fixes release please configurations.

In summary, 

Changes include: -
- Fix misaligned versions in `release-please-manifest.json`
- Reverts version bumps in [this PR](https://github.com/microsoft/kiota-typescript/pull/1399) so that we validate release please doing this. 
- Update versioning strategy to `prerelease` till we get GA.
- Fixes tag to match current tag conventions so that release please can find them.
