### PR TITLE
fix: ensure versions are aligned

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "exclude-paths": [".git", ".idea", ".github", ".vscode"],
   "include-component-in-tag": true,
   "include-v-in-tag": false,
+  "bootstrap-sha": "ac4f003257b909d7ca714e40d1704b48e7fdeca7",
   "tag-separator": "@",
   "separate-pull-requests": false,
   "bump-minor-pre-major": true,
@@ -55,5 +56,22 @@
       "changelog-path": "CHANGELOG.md"
     }
   },
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "microsoft-kiota",
+      "components": [
+        "@microsoft/kiota-abstractions",
+        "@microsoft/kiota-authentication-azure",
+        "@microsoft/kiota-authentication-spfx",
+        "@microsoft/kiota-bundle",
+        "@microsoft/kiota-http-fetchlibrary",
+        "@microsoft/kiota-serialization-form",
+        "@microsoft/kiota-serialization-json",
+        "@microsoft/kiota-serialization-multipart",
+        "@microsoft/kiota-serialization-text"
+      ]
+    }
+  ],
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
Ensures versions are aligned on release so that not only one package version is updated. 