### PR TITLE
chore: use tagging from release please.

### DIFF
--- a/.github/workflows/build_test_validate.yml
+++ b/.github/workflows/build_test_validate.yml
@@ -49,7 +49,7 @@ jobs:
 
   publish-npm:
     if: "${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'chore: release main') }}"
-    needs: build
+    needs: [build, check-typescript-version-matrix]
     environment:
       name: production_feed
     runs-on: ubuntu-latest
@@ -67,7 +67,7 @@ jobs:
             GITHUB_ACTOR: ${{ secrets.GIT_USERNAME }}
       - run: npm ci
       - run: npm run build
-      - run: npx lerna publish from-package --yes
+      - run: npx lerna publish from-package --no-push --yes
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,6 @@
   "separate-pull-requests": false,
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "skip-github-release": true,
   "versioning": "prerelease",
   "packages": {
     "packages/abstractions": {


### PR DESCRIPTION
Lets release please create the tags rather than lerna. 

This unblocks release PR generation as the labels are not dropped from previously merged release please PRs