### PR TITLE
fix: set version in package files to be updated by release please

### DIFF
--- a/packages/authentication/azure/package.json
+++ b/packages/authentication/azure/package.json
@@ -32,7 +32,7 @@
 	"homepage": "https://github.com/microsoft/kiota-typescript#readme",
 	"dependencies": {
 		"@azure/core-auth": "^1.5.0",
-		"@microsoft/kiota-abstractions": "*",
+		"@microsoft/kiota-abstractions": "^1.0.0-preview.70",
 		"@opentelemetry/api": "^1.7.0",
 		"tslib": "^2.6.2"
 	},

--- a/packages/authentication/spfx/package.json
+++ b/packages/authentication/spfx/package.json
@@ -41,7 +41,7 @@
 	},
 	"homepage": "https://github.com/microsoft/kiota-typescript#readme",
 	"dependencies": {
-		"@microsoft/kiota-abstractions": "*",
+		"@microsoft/kiota-abstractions": "^1.0.0-preview.70",
 		"@microsoft/sp-http": "^1.15.2",
 		"@opentelemetry/api": "^1.7.0",
 		"tslib": "^2.6.2"

--- a/packages/bundle/package.json
+++ b/packages/bundle/package.json
@@ -30,12 +30,12 @@
 	},
 	"homepage": "https://github.com/microsoft/kiota#readme",
 	"dependencies": {
-		"@microsoft/kiota-abstractions": "*",
-		"@microsoft/kiota-http-fetchlibrary": "*",
-		"@microsoft/kiota-serialization-form": "*",
-		"@microsoft/kiota-serialization-json": "*",
-		"@microsoft/kiota-serialization-multipart": "*",
-		"@microsoft/kiota-serialization-text": "*"
+		"@microsoft/kiota-abstractions": "^1.0.0-preview.70",
+		"@microsoft/kiota-http-fetchlibrary": "^1.0.0-preview.70",
+		"@microsoft/kiota-serialization-form": "^1.0.0-preview.70",
+		"@microsoft/kiota-serialization-json": "^1.0.0-preview.70",
+		"@microsoft/kiota-serialization-multipart": "^1.0.0-preview.70",
+		"@microsoft/kiota-serialization-text": "^1.0.0-preview.70"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/http/fetch/package.json
+++ b/packages/http/fetch/package.json
@@ -33,7 +33,7 @@
 		"test": "npm run test:node && npm run test:browser"
 	},
 	"dependencies": {
-		"@microsoft/kiota-abstractions": "*",
+		"@microsoft/kiota-abstractions": "^1.0.0-preview.70",
 		"@opentelemetry/api": "^1.7.0",
 		"guid-typescript": "^1.0.9",
 		"tslib": "^2.6.2"

--- a/packages/serialization/form/package.json
+++ b/packages/serialization/form/package.json
@@ -38,7 +38,7 @@
 	},
 	"homepage": "https://github.com/microsoft/kiota-typescript#readme",
 	"dependencies": {
-		"@microsoft/kiota-abstractions": "*",
+		"@microsoft/kiota-abstractions": "^1.0.0-preview.70",
 		"guid-typescript": "^1.0.9",
 		"tslib": "^2.6.2"
 	},

--- a/packages/serialization/json/package.json
+++ b/packages/serialization/json/package.json
@@ -38,7 +38,7 @@
 	},
 	"homepage": "https://github.com/microsoft/kiota-typescript#readme",
 	"dependencies": {
-		"@microsoft/kiota-abstractions": "*",
+		"@microsoft/kiota-abstractions": "^1.0.0-preview.70",
 		"guid-typescript": "^1.0.9",
 		"tslib": "^2.6.2"
 	},

--- a/packages/serialization/multipart/package.json
+++ b/packages/serialization/multipart/package.json
@@ -34,12 +34,12 @@
 	},
 	"homepage": "https://github.com/microsoft/kiota-typescript#readme",
 	"dependencies": {
-		"@microsoft/kiota-abstractions": "*",
+		"@microsoft/kiota-abstractions": "^1.0.0-preview.70",
 		"guid-typescript": "^1.0.9",
 		"tslib": "^2.6.2"
 	},
 	"devDependencies": {
-		"@microsoft/kiota-serialization-json": "*"
+		"@microsoft/kiota-serialization-json": "^1.0.0-preview.70"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/serialization/text/package.json
+++ b/packages/serialization/text/package.json
@@ -38,7 +38,7 @@
 	},
 	"homepage": "https://github.com/microsoft/kiota-typescript#readme",
 	"dependencies": {
-		"@microsoft/kiota-abstractions": "*",
+		"@microsoft/kiota-abstractions": "^1.0.0-preview.70",
 		"guid-typescript": "^1.0.9",
 		"tslib": "^2.6.2"
 	},

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -57,6 +57,10 @@
   },
   "plugins": [
     {
+      "type": "node-workspace",
+      "merge": false
+    },
+    {
       "type": "linked-versions",
       "groupName": "microsoft-kiota",
       "components": [


### PR DESCRIPTION
Fixes https://github.com/microsoft/kiota-typescript/issues/1440

Sets versions for dependency packages explicitly in the package files to ensure that the correct versions are installed by the release process. Release please should then update the dependencies with the packages similar to the test PR created at https://github.com/microsoft/kiota-typescript/pull/1444