### PR TITLE
fix: removed export for guid part generation

### DIFF
--- a/packages/abstractions/src/utils/guidUtils.ts
+++ b/packages/abstractions/src/utils/guidUtils.ts
@@ -31,7 +31,7 @@ export const createGuid = () => [gen(2), gen(1), gen(1), gen(1), gen(3)].join("-
  * @param count the number of 2 byte chunks to generate.
  * @returns a part of a GUID.
  */
-export const gen = (count: number) => {
+const gen = (count: number) => {
 	let out = "";
 	for (let i = 0; i < count; i++) {
 		// eslint-disable-next-line no-bitwise


### PR DESCRIPTION
Accepted suggestion from [microsoft/kiota-typescript#1475](https://github.com/microsoft/kiota-typescript/pull/1475)