### PR TITLE
fix: update std-uritemplate to v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3528,9 +3528,10 @@
       "dev": true
     },
     "node_modules/@std-uritemplate/std-uritemplate": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-1.0.6.tgz",
-      "integrity": "sha512-+S9kAqK60nZZyvhvesoXut6NB9qB80VTpNsdiOeHmE0FAMOEsJy9/dakDL3xMp3kNRFvviw0mX9WPSuasvSxCQ=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-2.0.1.tgz",
+      "integrity": "sha512-HC5kiXCa7Mxrv7SI7qH4ECfC1H+vFG15COBtX8aUur8EGEWK17RH3QVyBxtyjUXE448O4fGhQHh3kirEvPGWjw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.13",
@@ -16413,7 +16414,7 @@
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.7.0",
-        "@std-uritemplate/std-uritemplate": "^1.0.1",
+        "@std-uritemplate/std-uritemplate": "^2.0.0",
         "tinyduration": "^3.3.0",
         "tslib": "^2.6.2",
         "uuid": "^11.0.2"

--- a/packages/abstractions/package.json
+++ b/packages/abstractions/package.json
@@ -35,7 +35,7 @@
 	},
 	"dependencies": {
 		"@opentelemetry/api": "^1.7.0",
-		"@std-uritemplate/std-uritemplate": "^1.0.1",
+		"@std-uritemplate/std-uritemplate": "^2.0.0",
 		"tinyduration": "^3.3.0",
 		"tslib": "^2.6.2",
 		"uuid": "^11.0.2"

--- a/packages/abstractions/src/requestInformation.ts
+++ b/packages/abstractions/src/requestInformation.ts
@@ -240,7 +240,7 @@ export class RequestInformation implements RequestInformationSetContent {
 	};
 
 	private normalizeValue(value: unknown): unknown {
-		if (value instanceof DateOnly || value instanceof TimeOnly) {
+		if (value instanceof DateOnly || value instanceof TimeOnly || value instanceof Duration) {
 			return value.toString();
 		}
 		if (value instanceof Date) {

--- a/packages/abstractions/src/requestInformation.ts
+++ b/packages/abstractions/src/requestInformation.ts
@@ -267,7 +267,7 @@ export class RequestInformation implements RequestInformationSetContent {
 				}
 			}
 			if (typeof v === "boolean" || typeof v === "number" || typeof v === "string" || Array.isArray(v)) this.queryParameters[key] = v;
-			else if (v instanceof DateOnly || v instanceof TimeOnly) this.queryParameters[key] = v.toString();
+			else if (v instanceof DateOnly || v instanceof TimeOnly || v instanceof Duration) this.queryParameters[key] = v.toString();
 			else if (v instanceof Date) this.queryParameters[key] = v.toISOString();
 			else if (v === undefined) this.queryParameters[key] = undefined;
 		});

--- a/packages/abstractions/test/common/requestInformation.ts
+++ b/packages/abstractions/test/common/requestInformation.ts
@@ -7,7 +7,7 @@
 
 import { assert, describe, it } from "vitest";
 
-import { DateOnly, HttpMethod, type Guid, type Parsable, parseGuidString, type RequestAdapter, RequestInformation, type SerializationWriter, type SerializationWriterFactory, TimeOnly } from "../../src";
+import { DateOnly, HttpMethod, type Guid, type Parsable, parseGuidString, type RequestAdapter, RequestInformation, type SerializationWriter, type SerializationWriterFactory, TimeOnly, Duration } from "../../src";
 import { MultipartBody } from "../../src/multipartBody";
 import { TestEnum } from "./store/testEnum";
 
@@ -25,6 +25,8 @@ interface GetQueryParameters {
 	endTime?: TimeOnly;
 	endDate?: DateOnly;
 	timeStamp?: Date;
+  time?: TimeOnly;
+  duration?: Duration;
 }
 
 const getQueryParameterMapper: Record<string, string> = {
@@ -221,13 +223,13 @@ describe("RequestInformation", () => {
 	});
 
 	it("should correctly handle custom type in query/path parameter", () => {
-		const expected: string = `http://localhost/users/33933a8d-32bb-c6a8-784a-f60b5a1dd66a/2021-12-12?objectId=83afbf49-5583-152c-d7fb-176105d518bc&startDate=2021-12-12&startTime=23%3A12%3A00.0000000&timeStamp=2024-06-11T00%3A00%3A00.000Z`;
+		const expected: string = `http://localhost/users/33933a8d-32bb-c6a8-784a-f60b5a1dd66a/2021-12-12?objectId=83afbf49-5583-152c-d7fb-176105d518bc&startDate=2021-12-12&startTime=23%3A12%3A00.0000000&timeStamp=2024-06-11T00%3A00%3A00.000Z&duration=P1D&time=23:12:00.0000000`;
 		const requestInformation = new RequestInformation(HttpMethod.GET);
 		requestInformation.pathParameters["baseurl"] = baseUrl;
 		requestInformation.pathParameters["userId"] = parseGuidString("33933a8d-32bb-c6a8-784a-f60b5a1dd66a");
 		requestInformation.pathParameters["date"] = DateOnly.parse("2021-12-12");
-		requestInformation.urlTemplate = "http://localhost/users/{userId}/{date}{?objectId,startDate,startTime,endDate,endTime,timeStamp}";
-		requestInformation.setQueryStringParametersFromRawObject<GetQueryParameters>({ objectId: parseGuidString("83afbf49-5583-152c-d7fb-176105d518bc"), startDate: new DateOnly({ year: 2021, month: 12, day: 12 }), startTime: new TimeOnly({ hours: 23, minutes: 12 }), timeStamp: new Date("2024-06-11T00:00:00.000Z") }, getQueryParameterMapper);
+		requestInformation.urlTemplate = "http://localhost/users/{userId}/{date}{?objectId,startDate,startTime,endDate,endTime,timeStamp,duration}";
+		requestInformation.setQueryStringParametersFromRawObject<GetQueryParameters>({ objectId: parseGuidString("83afbf49-5583-152c-d7fb-176105d518bc"), startDate: new DateOnly({ year: 2021, month: 12, day: 12 }), startTime: new TimeOnly({ hours: 23, minutes: 12 }), timeStamp: new Date("2024-06-11T00:00:00.000Z"), duration: Duration.parse("P1D"), time: TimeOnly.parse("23:12:00.0000000") }, getQueryParameterMapper);
 		assert.equal(requestInformation.URL, expected);
 	});
 

--- a/packages/abstractions/test/common/requestInformation.ts
+++ b/packages/abstractions/test/common/requestInformation.ts
@@ -25,8 +25,7 @@ interface GetQueryParameters {
 	endTime?: TimeOnly;
 	endDate?: DateOnly;
 	timeStamp?: Date;
-  time?: TimeOnly;
-  duration?: Duration;
+	duration?: Duration;
 }
 
 const getQueryParameterMapper: Record<string, string> = {

--- a/packages/abstractions/test/common/requestInformation.ts
+++ b/packages/abstractions/test/common/requestInformation.ts
@@ -223,13 +223,13 @@ describe("RequestInformation", () => {
 	});
 
 	it("should correctly handle custom type in query/path parameter", () => {
-		const expected: string = `http://localhost/users/33933a8d-32bb-c6a8-784a-f60b5a1dd66a/2021-12-12?objectId=83afbf49-5583-152c-d7fb-176105d518bc&startDate=2021-12-12&startTime=23%3A12%3A00.0000000&timeStamp=2024-06-11T00%3A00%3A00.000Z&duration=P1D&time=23:12:00.0000000`;
+		const expected: string = `http://localhost/users/33933a8d-32bb-c6a8-784a-f60b5a1dd66a/2021-12-12?objectId=83afbf49-5583-152c-d7fb-176105d518bc&startDate=2021-12-12&startTime=23%3A12%3A00.0000000&timeStamp=2024-06-11T00%3A00%3A00.000Z&duration=P1D`;
 		const requestInformation = new RequestInformation(HttpMethod.GET);
 		requestInformation.pathParameters["baseurl"] = baseUrl;
 		requestInformation.pathParameters["userId"] = parseGuidString("33933a8d-32bb-c6a8-784a-f60b5a1dd66a");
 		requestInformation.pathParameters["date"] = DateOnly.parse("2021-12-12");
 		requestInformation.urlTemplate = "http://localhost/users/{userId}/{date}{?objectId,startDate,startTime,endDate,endTime,timeStamp,duration}";
-		requestInformation.setQueryStringParametersFromRawObject<GetQueryParameters>({ objectId: parseGuidString("83afbf49-5583-152c-d7fb-176105d518bc"), startDate: new DateOnly({ year: 2021, month: 12, day: 12 }), startTime: new TimeOnly({ hours: 23, minutes: 12 }), timeStamp: new Date("2024-06-11T00:00:00.000Z"), duration: Duration.parse("P1D"), time: TimeOnly.parse("23:12:00.0000000") }, getQueryParameterMapper);
+		requestInformation.setQueryStringParametersFromRawObject<GetQueryParameters>({ objectId: parseGuidString("83afbf49-5583-152c-d7fb-176105d518bc"), startDate: new DateOnly({ year: 2021, month: 12, day: 12 }), startTime: new TimeOnly({ hours: 23, minutes: 12 }), timeStamp: new Date("2024-06-11T00:00:00.000Z"), duration: Duration.parse("P1D") }, getQueryParameterMapper);
 		assert.equal(requestInformation.URL, expected);
 	});
 


### PR DESCRIPTION
Closes #1384 

Updates the std-uritemplate package to v2.0.0. No further code changes required
https://github.com/microsoft/kiota-typescript/blob/7643e7c49b9318e74359f462e8063a4c7861efe0/packages/abstractions/src/requestInformation.ts#L242-L253

and passing tests

https://github.com/microsoft/kiota-typescript/blob/7643e7c49b9318e74359f462e8063a4c7861efe0/packages/abstractions/test/common/requestInformation.ts#L223-L232