### PR TITLE
feat(abstractions): create empty guid 

### DIFF
--- a/packages/abstractions/src/utils/guidUtils.ts
+++ b/packages/abstractions/src/utils/guidUtils.ts
@@ -27,6 +27,12 @@ export const parseGuidString = (source?: string) => {
 export const createGuid = () => [gen(2), gen(1), gen(1), gen(1), gen(3)].join("-");
 
 /**
+ * Generates a empty GUID.
+ * @returns a empty GUID.
+ */
+export const createEmptyGuid = () => "00000000-0000-0000-0000-000000000000";
+
+/**
  * Generates a part of a GUID.
  * @param count the number of 2 byte chunks to generate.
  * @returns a part of a GUID.


### PR DESCRIPTION
After update to 1.20.0 I saw that kiota don't use guid-typescript anymore and my code base is now missing method for generating empty guid