### PR TITLE
fix: remove zlib compression in node

### DIFF
--- a/packages/http/fetch/src/middlewares/compressionHandler.ts
+++ b/packages/http/fetch/src/middlewares/compressionHandler.ts
@@ -169,37 +169,13 @@ export class CompressionHandler implements Middleware {
 		compressedBody: ArrayBuffer | Buffer;
 		size: number;
 	}> {
-		if (!inNodeEnv()) {
-			// in browser
-			const compressionData = this.readBodyAsBytes(body);
-			const compressedBody = await this.compressUsingCompressionStream(compressionData.stream);
-			return {
-				compressedBody: compressedBody.body,
-				size: compressedBody.size,
-			};
-		} else {
-			// In Node.js
-			const compressedBody = await this.compressUsingZlib(body);
-			return {
-				compressedBody,
-				size: compressedBody.length,
-			};
-		}
-	}
-
-	private async compressUsingZlib(body: unknown): Promise<Buffer> {
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		const zlib = await import("zlib");
-		return await new Promise((resolve, reject) => {
-			zlib.gzip(body as string | ArrayBuffer | NodeJS.ArrayBufferView, (err, compressed) => {
-				if (err) {
-					reject(err);
-				} else {
-					resolve(compressed);
-				}
-			});
-		});
+		// in browser
+		const compressionData = this.readBodyAsBytes(body);
+		const compressedBody = await this.compressUsingCompressionStream(compressionData.stream);
+		return {
+			compressedBody: compressedBody.body,
+			size: compressedBody.size,
+		};
 	}
 
 	private async compressUsingCompressionStream(uint8ArrayStream: ReadableStream<Uint8Array>): Promise<{ body: ArrayBuffer; size: number }> {

--- a/packages/http/fetch/test/common/middleware/compressionHandler.ts
+++ b/packages/http/fetch/test/common/middleware/compressionHandler.ts
@@ -5,7 +5,6 @@ import { CompressionHandler } from "../../../src/middlewares/compressionHandler"
 const defaultOptions = new CompressionHandlerOptions();
 
 import { assert, describe, it, expect, beforeEach, vi } from "vitest";
-import { inNodeEnv } from "@microsoft/kiota-abstractions";
 
 describe("CompressionHandler", () => {
 	let compressionHandler: CompressionHandler;
@@ -63,7 +62,7 @@ describe("CompressionHandler", () => {
 
 		expect((requestInit.headers as Record<string, string>)["Content-Encoding"]).toBe("gzip");
 		const compressedBody = requestInit.body as unknown as ArrayBuffer;
-		const decompressedBody = inNodeEnv() ? await decompressUsingZlib(compressedBody) : await decompressUsingDecompressionStream(compressedBody);
+		const decompressedBody = await decompressUsingDecompressionStream(compressedBody);
 		expect(decompressedBody).toBe(requestBody);
 	});
 
@@ -102,28 +101,6 @@ describe("CompressionHandler", () => {
 		expect(response).toBeInstanceOf(Response);
 	});
 });
-
-// helper function to decompress ArrayBuffer using zlib
-async function decompressUsingZlib(arrayBuffer: ArrayBuffer): Promise<string> {
-	return new Promise(async (resolve, reject) => {
-		// @ts-ignore
-		const zlib = await import("zlib");
-		// Convert the ArrayBuffer to a Node.js Buffer
-		const buffer = Buffer.from(arrayBuffer);
-		console.log(buffer);
-
-		// Decompress the buffer
-		zlib.gunzip(buffer, (err, decompressedBuffer) => {
-			if (err) {
-				console.error(err);
-				return reject(err);
-			}
-			// Convert the decompressed Buffer to a string and resolve the promise
-			console.log("decompressed " + decompressedBuffer.toString());
-			resolve(decompressedBuffer.toString("utf-8"));
-		});
-	});
-}
 
 // helper function to convert ArrayBuffer to string using DecompressionStream
 async function decompressUsingDecompressionStream(compressedArrayBuffer: ArrayBuffer): Promise<string> {


### PR DESCRIPTION
Resolve https://github.com/microsoft/kiota-typescript/issues/1442

Removes support for zlib in compression handler (in node)