### PR TITLE
fix: SerializationWriter.writeByteArrayValue should accept a null value

### DIFF
--- a/packages/abstractions/src/serialization/serializationWriter.ts
+++ b/packages/abstractions/src/serialization/serializationWriter.ts
@@ -19,7 +19,7 @@ export interface SerializationWriter {
 	 * @param key the key to write the value with.
 	 * @param value the value to write to the stream.
 	 */
-	writeByteArrayValue(key?: string, value?: ArrayBuffer): void;
+	writeByteArrayValue(key?: string, value?: ArrayBuffer | null): void;
 	/**
 	 * Writes the specified string value to the stream with an optional given key.
 	 * @param key the key to write the value with.

--- a/packages/serialization/json/src/jsonSerializationWriter.ts
+++ b/packages/serialization/json/src/jsonSerializationWriter.ts
@@ -9,7 +9,7 @@
 import { DateOnly, Duration, type Guid, isUntypedNode, type ModelSerializerFunction, type Parsable, type SerializationWriter, TimeOnly, type UntypedNode, isUntypedBoolean, isUntypedString, isUntypedNull, isUntypedNumber, isUntypedObject, isUntypedArray, inNodeEnv } from "@microsoft/kiota-abstractions";
 
 export class JsonSerializationWriter implements SerializationWriter {
-	public writeByteArrayValue(key?: string, value?: ArrayBuffer): void {
+	public writeByteArrayValue(key?: string, value?: ArrayBuffer | null): void {
 		if (!value) {
 			throw new Error("value cannot be undefined");
 		}

--- a/packages/serialization/multipart/src/multipartSerializationWriter.ts
+++ b/packages/serialization/multipart/src/multipartSerializationWriter.ts
@@ -10,11 +10,7 @@ import { type DateOnly, type Duration, type Guid, MultipartBody, type Parsable, 
 
 /** Serialization writer for multipart/form-data */
 export class MultipartSerializationWriter implements SerializationWriter {
-	public writeByteArrayValue(
-		key?: string,
-
-		value?: ArrayBuffer,
-	): void {
+	public writeByteArrayValue(key?: string, value?: ArrayBuffer | null): void {
 		if (!value) {
 			throw new Error("value cannot be undefined");
 		}


### PR DESCRIPTION
Missing `null` in TypeScript `SerializationWriter.writeByteArrayValue` results in throwing an error with a null value is passed