### PR TITLE
fix: prevent error on undefined byte array value in serialization writers

### DIFF
--- a/packages/serialization/json/src/jsonSerializationWriter.ts
+++ b/packages/serialization/json/src/jsonSerializationWriter.ts
@@ -11,8 +11,9 @@ import { DateOnly, Duration, type Guid, isUntypedNode, type ModelSerializerFunct
 export class JsonSerializationWriter implements SerializationWriter {
 	public writeByteArrayValue(key?: string, value?: ArrayBuffer | null): void {
 		if (!value) {
-			throw new Error("value cannot be undefined");
+			return;
 		}
+
 		const b64 = inNodeEnv() ? Buffer.from(value).toString("base64") : btoa(new TextDecoder().decode(value));
 		this.writeStringValue(key, b64);
 	}

--- a/packages/serialization/text/src/textSerializationWriter.ts
+++ b/packages/serialization/text/src/textSerializationWriter.ts
@@ -11,10 +11,10 @@ import { inNodeEnv, type DateOnly, type Duration, type Guid, type ModelSerialize
 export class TextSerializationWriter implements SerializationWriter {
 	public writeByteArrayValue(key?: string, value?: ArrayBuffer | null): void {
 		if (!value) {
-			throw new Error("value cannot be undefined");
+			return;
 		}
-		const b64 = inNodeEnv() ? Buffer.from(value).toString("base64") : btoa(new TextDecoder().decode(value));
 
+		const b64 = inNodeEnv() ? Buffer.from(value).toString("base64") : btoa(new TextDecoder().decode(value));
 		this.writeStringValue(key, b64);
 	}
 	private static readonly noStructuredDataMessage = "text does not support structured data";


### PR DESCRIPTION
This PR fixes #1662 

Closes: #1662 