### PR TITLE
feat: Adds 304 to return undefined body

### DIFF
--- a/packages/http/fetch/src/fetchRequestAdapter.ts
+++ b/packages/http/fetch/src/fetchRequestAdapter.ts
@@ -366,7 +366,7 @@ export class FetchRequestAdapter implements RequestAdapter {
 		});
 	};
 	private readonly shouldReturnUndefined = (response: Response): boolean => {
-		return response.status === 204 || !response.body;
+		return response.status === 204 || response.status === 304 || !response.body;
 	};
 	/**
 	 * purges the response body if it hasn't been read to release the connection to the server


### PR DESCRIPTION
Resolves https://github.com/microsoft/kiota-typescript/issues/1673

Ensure status 304 always returns an empty body