### PR TITLE
Update apiClientProxifier.ts

### DIFF
--- a/packages/abstractions/src/apiClientProxifier.ts
+++ b/packages/abstractions/src/apiClientProxifier.ts
@@ -124,6 +124,9 @@ export const apiClientProxifier = <T extends object>(requestAdapter: RequestAdap
 					return apiClientProxifier(requestAdapter, getPathParameters(rawUrl), navigationMetadata, requestsMetadata);
 				};
 			}
+      if (name === "then") {
+        return undefined;
+      }
 			if (requestsMetadata) {
 				const metadataKey = getRequestMethod(name);
 				if (metadataKey) {


### PR DESCRIPTION
fix: Allow API Client Proxy to be returned from an async function. 

Closes #1725