### PR TITLE
Fix Incorrect Deserialization of null Values in Primitive Collections

### DIFF
--- a/packages/serialization/json/src/jsonParseNode.ts
+++ b/packages/serialization/json/src/jsonParseNode.ts
@@ -36,7 +36,7 @@ export class JsonParseNode implements ParseNode {
 			const currentParseNode = new JsonParseNode(x, this.backingStoreFactory);
 			const typeOfX = typeof x;
 			if (x === null) {
-				return null as T
+				return null as T;
 			} else if (typeOfX === "boolean") {
 				return currentParseNode.getBooleanValue() as unknown as T;
 			} else if (typeOfX === "string") {

--- a/packages/serialization/json/src/jsonParseNode.ts
+++ b/packages/serialization/json/src/jsonParseNode.ts
@@ -35,7 +35,9 @@ export class JsonParseNode implements ParseNode {
 		return (this._jsonNode as unknown[]).map((x) => {
 			const currentParseNode = new JsonParseNode(x, this.backingStoreFactory);
 			const typeOfX = typeof x;
-			if (typeOfX === "boolean") {
+      if (x === null) {
+        return null as T
+      } else if (typeOfX === "boolean") {
 				return currentParseNode.getBooleanValue() as unknown as T;
 			} else if (typeOfX === "string") {
 				return currentParseNode.getStringValue() as unknown as T;

--- a/packages/serialization/json/src/jsonParseNode.ts
+++ b/packages/serialization/json/src/jsonParseNode.ts
@@ -35,9 +35,9 @@ export class JsonParseNode implements ParseNode {
 		return (this._jsonNode as unknown[]).map((x) => {
 			const currentParseNode = new JsonParseNode(x, this.backingStoreFactory);
 			const typeOfX = typeof x;
-      if (x === null) {
-        return null as T
-      } else if (typeOfX === "boolean") {
+			if (x === null) {
+				return null as T
+			} else if (typeOfX === "boolean") {
 				return currentParseNode.getBooleanValue() as unknown as T;
 			} else if (typeOfX === "string") {
 				return currentParseNode.getStringValue() as unknown as T;


### PR DESCRIPTION
When deserializing a JSON array of primitive types that contains null values, the getCollectionOfPrimitiveValues method in CustomJsonParseNode fails to correctly handle the null entries. The current implementation attempts to create a new CustomJsonParseNode(null) and then process it, leading to a TypeError because it falls into the else block which throws an error for unknown types.

To Reproduce:

Attempt to parse a JSON payload containing an array of primitives with a null value, for example: ["value1", null, "value2"].

Expected Behavior:

The getCollectionOfPrimitiveValues method should correctly deserialize the array, preserving the null values, resulting in an output like ["value1", null, "value2"].