### PR TITLE
fix(http): case insensitive header removal

### DIFF
--- a/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
@@ -73,12 +73,19 @@ export class RedirectHandlerOptions implements RequestOption {
 			const originalUri = new URL(originalUrl);
 			const newUri = new URL(newUrl);
 
-			// Remove Authorization and Cookie headers if the request's scheme or host changes
+			// Remove Authorization, Cookie, and Proxy-Authorization headers if the request's scheme or host changes.
+			// Header keys must be matched case-insensitively because FetchRequestAdapter.getRequestFromRequestInformation
+			// lower-cases every header key before the headers object reaches this middleware, so PascalCase
+			// property deletes such as `delete headers.Authorization` would otherwise be a no-op.
 			const isDifferentHostOrScheme = originalUri.host.toLowerCase() !== newUri.host.toLowerCase() || originalUri.protocol.toLowerCase() !== newUri.protocol.toLowerCase();
 
 			if (isDifferentHostOrScheme) {
-				delete headers.Authorization;
-				delete headers.Cookie;
+				for (const key of Object.keys(headers)) {
+					const lower = key.toLowerCase();
+					if (lower === "authorization" || lower === "cookie" || lower === "proxy-authorization") {
+						delete headers[key];
+					}
+				}
 			}
 		} catch {
 			// If URL parsing fails, don't modify headers

--- a/packages/http/fetch/test/node/RedirectHandler.ts
+++ b/packages/http/fetch/test/node/RedirectHandler.ts
@@ -352,6 +352,40 @@ describe("RedirectHandler.ts", () => {
 			assert.equal(response.status, 200);
 		});
 
+		it("Should drop authorization, cookie, and proxy-authorization headers regardless of key case for cross-host redirect", async () => {
+			// FetchRequestAdapter.getRequestFromRequestInformation lower-cases every header
+			// key before it reaches the redirect handler, so the default scrub must be
+			// case-insensitive when matching sensitive header names.
+			const requestUrl = "https://graph.microsoft.com/v1.0/me";
+			const fetchRequestInit = {
+				method: "POST",
+				body: "dummy body",
+				headers: {
+					authorization: "Bearer TEST",
+					cookie: "session=SECRET",
+					"proxy-authorization": "Basic dXNlcjpwYXNz",
+					AUTHORIZATION: "Bearer SHOULDTY",
+				},
+			};
+
+			dummyFetchHandler.setResponses([
+				new Response(null, {
+					status: 301,
+					headers: {
+						[RedirectHandler["LOCATION_HEADER"]]: "https://graphredirect.microsoft.com/v1.0/me",
+					},
+				}),
+				new Response("ok", { status: 200 }),
+			] as any);
+			const response = await handler["executeWithRedirect"](requestUrl, fetchRequestInit, 0, new RedirectHandlerOptions());
+			const finalHeaders = fetchRequestInit.headers as Record<string, string>;
+			assert.isUndefined(finalHeaders["authorization"]);
+			assert.isUndefined(finalHeaders["cookie"]);
+			assert.isUndefined(finalHeaders["proxy-authorization"]);
+			assert.isUndefined(finalHeaders["AUTHORIZATION"]);
+			assert.equal(response.status, 200);
+		});
+
 		it("Should drop Authorization and Cookie headers for scheme change", async () => {
 			const requestUrl = "https://graph.microsoft.com/v1.0/me";
 			const fetchRequestInit = {


### PR DESCRIPTION
FetchRequestAdapter.getRequestFromRequestInformation lower-cases every
header key before the headers object reaches RedirectHandler. The
default scrubSensitiveHeaders callback in RedirectHandlerOptions used
PascalCase property deletes (delete headers.Authorization,
delete headers.Cookie) which therefore matched no keys, leaving the
sensitive headers in place when the redirect handler forwarded the
request to a different origin.

The unit tests passed because they constructed RequestInit objects
with PascalCase header keys directly, bypassing the lower-casing
step performed by the production code path.

Replace the case-sensitive deletes with an Object.keys walk that
normalises each key before comparing it against the sensitive set
(authorization, cookie, proxy-authorization). Add a regression test
that exercises the realistic lower-cased shape.
