### PR TITLE
fix(serialization): pass primitive collection type

### DIFF
--- a/packages/abstractions/src/apiClientProxifier.ts
+++ b/packages/abstractions/src/apiClientProxifier.ts
@@ -6,7 +6,7 @@
  */
 import { getPathParameters } from "./getPathParameters";
 import { HttpMethod } from "./httpMethod";
-import type { ErrorMappings, PrimitiveTypesForDeserialization, PrimitiveTypesForDeserializationType, RequestAdapter, SendMethods } from "./requestAdapter";
+import type { ErrorMappings, PrimitiveTypesForDeserialization, PrimitiveTypesForDeserializationForCollection, PrimitiveTypesForDeserializationType, RequestAdapter, SendMethods } from "./requestAdapter";
 import type { RequestConfiguration } from "./requestConfiguration";
 import { RequestInformation, type RequestInformationSetContent } from "./requestInformation";
 import type { ModelSerializerFunction, Parsable, ParsableFactory } from "./serialization";
@@ -100,7 +100,7 @@ const send = (requestAdapter: RequestAdapter, requestInfo: RequestInformation, m
 			if (!metadata.responseBodyFactory) {
 				throw new Error("couldn't find response body factory");
 			}
-			return requestAdapter.sendCollectionOfPrimitive(requestInfo, metadata.responseBodyFactory as Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer">, metadata.errorMappings);
+			return requestAdapter.sendCollectionOfPrimitive(requestInfo, metadata.responseBodyFactory as PrimitiveTypesForDeserializationForCollection, metadata.errorMappings);
 		case "sendPrimitive":
 			if (!metadata.responseBodyFactory) {
 				throw new Error("couldn't find response body factory");

--- a/packages/abstractions/src/requestAdapter.ts
+++ b/packages/abstractions/src/requestAdapter.ts
@@ -110,8 +110,10 @@ export type PrimitiveTypesForDeserializationType = string | number | boolean | D
 
 export type PrimitiveTypesForDeserialization = "string" | "number" | "boolean" | "Date" | "DateOnly" | "TimeOnly" | "Duration" | "ArrayBuffer";
 
+/** Primitive value types supported for collection response deserialization. */
 export type PrimitiveTypesForDeserializationTypeForCollection = Exclude<PrimitiveTypesForDeserializationType, ArrayBuffer>;
 
+/** Runtime primitive type names supported for collection response deserialization. */
 export type PrimitiveTypesForDeserializationForCollection = Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer">;
 
 export type SendMethods = Exclude<keyof RequestAdapter, "enableBackingStore" | "getSerializationWriterFactory" | "convertToNativeRequest" | "baseUrl">;

--- a/packages/abstractions/src/requestAdapter.ts
+++ b/packages/abstractions/src/requestAdapter.ts
@@ -51,7 +51,7 @@ export interface RequestAdapter {
 	 * @param errorMappings the error factories mapping to use in case of a failed request.
 	 * @returns a {@link Promise} with the deserialized response model collection.
 	 */
-	sendCollectionOfPrimitive<ResponseType extends Exclude<PrimitiveTypesForDeserializationType, ArrayBuffer>>(requestInfo: RequestInformation, responseType: Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer">, errorMappings: ErrorMappings | undefined): Promise<ResponseType[] | undefined>;
+	sendCollectionOfPrimitive<ResponseType extends PrimitiveTypesForDeserializationTypeForCollection>(requestInfo: RequestInformation, responseType: PrimitiveTypesForDeserializationForCollection, errorMappings: ErrorMappings | undefined): Promise<ResponseType[] | undefined>;
 	/**
 	 * Executes the HTTP request specified by the given RequestInformation and returns the deserialized primitive response model.
 	 * @param requestInfo the request info to execute.
@@ -109,5 +109,9 @@ export interface ErrorMappings {
 export type PrimitiveTypesForDeserializationType = string | number | boolean | Date | DateOnly | TimeOnly | Duration | ArrayBuffer;
 
 export type PrimitiveTypesForDeserialization = "string" | "number" | "boolean" | "Date" | "DateOnly" | "TimeOnly" | "Duration" | "ArrayBuffer";
+
+export type PrimitiveTypesForDeserializationTypeForCollection = Exclude<PrimitiveTypesForDeserializationType, ArrayBuffer>;
+
+export type PrimitiveTypesForDeserializationForCollection = Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer">;
 
 export type SendMethods = Exclude<keyof RequestAdapter, "enableBackingStore" | "getSerializationWriterFactory" | "convertToNativeRequest" | "baseUrl">;

--- a/packages/abstractions/src/serialization/parseNode.ts
+++ b/packages/abstractions/src/serialization/parseNode.ts
@@ -8,6 +8,7 @@ import type { Guid } from "../utils/guidUtils";
 
 import type { DateOnly } from "../dateOnly";
 import type { Duration } from "../duration";
+import type { PrimitiveTypesForDeserialization } from "../requestAdapter";
 import type { TimeOnly } from "../timeOnly";
 import type { Parsable } from "./parsable";
 import type { ParsableFactory } from "./parsableFactory";
@@ -64,9 +65,10 @@ export interface ParseNode {
 	getTimeOnlyValue(): TimeOnly | undefined;
 	/**
 	 * Gets the collection of primitive values of the node.
+	 * @param primitiveType the runtime primitive type to deserialize collection items into.
 	 * @returns the collection of primitive values of the node.
 	 */
-	getCollectionOfPrimitiveValues<T>(): T[] | undefined;
+	getCollectionOfPrimitiveValues<T>(primitiveType?: Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer">): T[] | undefined;
 	/**
 	 * Gets the collection of object values of the node.
 	 * @returns the collection of object values of the node.

--- a/packages/abstractions/src/serialization/parseNode.ts
+++ b/packages/abstractions/src/serialization/parseNode.ts
@@ -8,7 +8,7 @@ import type { Guid } from "../utils/guidUtils";
 
 import type { DateOnly } from "../dateOnly";
 import type { Duration } from "../duration";
-import type { PrimitiveTypesForDeserialization } from "../requestAdapter";
+import type { PrimitiveTypesForDeserializationForCollection } from "../requestAdapter";
 import type { TimeOnly } from "../timeOnly";
 import type { Parsable } from "./parsable";
 import type { ParsableFactory } from "./parsableFactory";
@@ -68,7 +68,7 @@ export interface ParseNode {
 	 * @param primitiveType the runtime primitive type to deserialize collection items into.
 	 * @returns the collection of primitive values of the node.
 	 */
-	getCollectionOfPrimitiveValues<T>(primitiveType?: Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer">): T[] | undefined;
+	getCollectionOfPrimitiveValues<T>(primitiveType?: PrimitiveTypesForDeserializationForCollection): T[] | undefined;
 	/**
 	 * Gets the collection of object values of the node.
 	 * @returns the collection of object values of the node.

--- a/packages/abstractions/src/serialization/parseNode.ts
+++ b/packages/abstractions/src/serialization/parseNode.ts
@@ -68,7 +68,7 @@ export interface ParseNode {
 	 * @param primitiveType the runtime primitive type to deserialize collection items into.
 	 * @returns the collection of primitive values of the node.
 	 */
-	getCollectionOfPrimitiveValues<T>(primitiveType?: PrimitiveTypesForDeserializationForCollection): T[] | undefined;
+	getCollectionOfPrimitiveValues<T>(primitiveType: PrimitiveTypesForDeserializationForCollection): T[] | undefined;
 	/**
 	 * Gets the collection of object values of the node.
 	 * @returns the collection of object values of the node.

--- a/packages/http/fetch/src/fetchRequestAdapter.ts
+++ b/packages/http/fetch/src/fetchRequestAdapter.ts
@@ -95,25 +95,28 @@ export class FetchRequestAdapter implements RequestAdapter {
 						case "number":
 						case "boolean":
 						case "Date":
+						case "Duration":
+						case "DateOnly":
+						case "TimeOnly":
 							// eslint-disable-next-line no-case-declarations
 							const rootNode = await this.getRootParseNode(response);
 							return trace.getTracer(this.observabilityOptions.getTracerInstrumentationName()).startActiveSpan(`getCollectionOf${responseType}Value`, (deserializeSpan) => {
 								try {
 									span.setAttribute(FetchRequestAdapter.responseTypeAttributeKey, responseType);
 									if (responseType === "string") {
-										return rootNode.getCollectionOfPrimitiveValues<string>() as unknown as ResponseType[];
+										return rootNode.getCollectionOfPrimitiveValues<string>(responseType) as unknown as ResponseType[];
 									} else if (responseType === "number") {
-										return rootNode.getCollectionOfPrimitiveValues<number>() as unknown as ResponseType[];
+										return rootNode.getCollectionOfPrimitiveValues<number>(responseType) as unknown as ResponseType[];
 									} else if (responseType === "boolean") {
-										return rootNode.getCollectionOfPrimitiveValues<boolean>() as unknown as ResponseType[];
+										return rootNode.getCollectionOfPrimitiveValues<boolean>(responseType) as unknown as ResponseType[];
 									} else if (responseType === "Date") {
-										return rootNode.getCollectionOfPrimitiveValues<Date>() as unknown as ResponseType[];
+										return rootNode.getCollectionOfPrimitiveValues<Date>(responseType) as unknown as ResponseType[];
 									} else if (responseType === "Duration") {
-										return rootNode.getCollectionOfPrimitiveValues<Duration>() as unknown as ResponseType[];
+										return rootNode.getCollectionOfPrimitiveValues<Duration>(responseType) as unknown as ResponseType[];
 									} else if (responseType === "DateOnly") {
-										return rootNode.getCollectionOfPrimitiveValues<DateOnly>() as unknown as ResponseType[];
+										return rootNode.getCollectionOfPrimitiveValues<DateOnly>(responseType) as unknown as ResponseType[];
 									} else if (responseType === "TimeOnly") {
-										return rootNode.getCollectionOfPrimitiveValues<TimeOnly>() as unknown as ResponseType[];
+										return rootNode.getCollectionOfPrimitiveValues<TimeOnly>(responseType) as unknown as ResponseType[];
 									} else {
 										throw new Error("unexpected type to deserialize");
 									}

--- a/packages/http/fetch/src/fetchRequestAdapter.ts
+++ b/packages/http/fetch/src/fetchRequestAdapter.ts
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { type ApiError, type AuthenticationProvider, type BackingStoreFactory, InMemoryBackingStoreFactory, type DateOnly, DefaultApiError, type Duration, enableBackingStoreForParseNodeFactory, enableBackingStoreForSerializationWriterFactory, type ErrorMappings, type Parsable, type ParsableFactory, type ParseNode, type ParseNodeFactory, ParseNodeFactoryRegistry, type PrimitiveTypesForDeserialization, type PrimitiveTypesForDeserializationType, type RequestAdapter, type RequestInformation, type ResponseHandler, type ResponseHandlerOption, ResponseHandlerOptionKey, type SerializationWriterFactory, SerializationWriterFactoryRegistry, type TimeOnly } from "@microsoft/kiota-abstractions";
+import { type ApiError, type AuthenticationProvider, type BackingStoreFactory, InMemoryBackingStoreFactory, type DateOnly, DefaultApiError, type Duration, enableBackingStoreForParseNodeFactory, enableBackingStoreForSerializationWriterFactory, type ErrorMappings, type Parsable, type ParsableFactory, type ParseNode, type ParseNodeFactory, ParseNodeFactoryRegistry, type PrimitiveTypesForDeserialization, type PrimitiveTypesForDeserializationForCollection, type PrimitiveTypesForDeserializationType, type PrimitiveTypesForDeserializationTypeForCollection, type RequestAdapter, type RequestInformation, type ResponseHandler, type ResponseHandlerOption, ResponseHandlerOptionKey, type SerializationWriterFactory, SerializationWriterFactoryRegistry, type TimeOnly } from "@microsoft/kiota-abstractions";
 import { type Span, SpanStatusCode, trace } from "@opentelemetry/api";
 import { HttpClient } from "./httpClient";
 import { type ObservabilityOptions, ObservabilityOptionsImpl } from "./observabilityOptions";
@@ -76,7 +76,7 @@ export class FetchRequestAdapter implements RequestAdapter {
 		return responseHandlerOption?.responseHandler;
 	};
 	private static readonly responseTypeAttributeKey = "com.microsoft.kiota.response.type";
-	public sendCollectionOfPrimitive = <ResponseType extends Exclude<PrimitiveTypesForDeserializationType, ArrayBuffer>>(requestInfo: RequestInformation, responseType: Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer">, errorMappings: ErrorMappings | undefined): Promise<ResponseType[] | undefined> => {
+	public sendCollectionOfPrimitive = <ResponseType extends PrimitiveTypesForDeserializationTypeForCollection>(requestInfo: RequestInformation, responseType: PrimitiveTypesForDeserializationForCollection, errorMappings: ErrorMappings | undefined): Promise<ResponseType[] | undefined> => {
 		if (!requestInfo) {
 			throw new Error("requestInfo cannot be null");
 		}

--- a/packages/http/fetch/test/common/mockParseNodeFactory.ts
+++ b/packages/http/fetch/test/common/mockParseNodeFactory.ts
@@ -6,7 +6,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import type { DateOnly, Duration, Guid, Parsable, ParsableFactory, ParseNode, ParseNodeFactory, TimeOnly } from "@microsoft/kiota-abstractions";
+import type { DateOnly, Duration, Guid, Parsable, ParsableFactory, ParseNode, ParseNodeFactory, PrimitiveTypesForDeserialization, TimeOnly } from "@microsoft/kiota-abstractions";
 
 export class MockParseNodeFactory implements ParseNodeFactory {
 	parseNodeValue: ParseNode;
@@ -62,7 +62,7 @@ export class MockParseNode implements ParseNode {
 	getTimeOnlyValue(): TimeOnly | undefined {
 		throw new Error("Method not implemented.");
 	}
-	getCollectionOfPrimitiveValues<T>(): T[] | undefined {
+	getCollectionOfPrimitiveValues<T>(_primitiveType?: Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer">): T[] | undefined {
 		throw new Error("Method not implemented.");
 	}
 	getCollectionOfObjectValues<T extends Parsable>(type: ParsableFactory<T>): T[] | undefined {

--- a/packages/http/fetch/test/common/mockParseNodeFactory.ts
+++ b/packages/http/fetch/test/common/mockParseNodeFactory.ts
@@ -6,7 +6,7 @@
  */
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import type { DateOnly, Duration, Guid, Parsable, ParsableFactory, ParseNode, ParseNodeFactory, PrimitiveTypesForDeserialization, TimeOnly } from "@microsoft/kiota-abstractions";
+import type { DateOnly, Duration, Guid, Parsable, ParsableFactory, ParseNode, ParseNodeFactory, PrimitiveTypesForDeserializationForCollection, TimeOnly } from "@microsoft/kiota-abstractions";
 
 export class MockParseNodeFactory implements ParseNodeFactory {
 	parseNodeValue: ParseNode;
@@ -62,7 +62,7 @@ export class MockParseNode implements ParseNode {
 	getTimeOnlyValue(): TimeOnly | undefined {
 		throw new Error("Method not implemented.");
 	}
-	getCollectionOfPrimitiveValues<T>(_primitiveType?: Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer">): T[] | undefined {
+	getCollectionOfPrimitiveValues<T>(_primitiveType?: PrimitiveTypesForDeserializationForCollection): T[] | undefined {
 		throw new Error("Method not implemented.");
 	}
 	getCollectionOfObjectValues<T extends Parsable>(type: ParsableFactory<T>): T[] | undefined {

--- a/packages/http/fetch/test/common/mockParseNodeFactory.ts
+++ b/packages/http/fetch/test/common/mockParseNodeFactory.ts
@@ -62,7 +62,7 @@ export class MockParseNode implements ParseNode {
 	getTimeOnlyValue(): TimeOnly | undefined {
 		throw new Error("Method not implemented.");
 	}
-	getCollectionOfPrimitiveValues<T>(_primitiveType?: PrimitiveTypesForDeserializationForCollection): T[] | undefined {
+	getCollectionOfPrimitiveValues<T>(_primitiveType: PrimitiveTypesForDeserializationForCollection): T[] | undefined {
 		throw new Error("Method not implemented.");
 	}
 	getCollectionOfObjectValues<T extends Parsable>(type: ParsableFactory<T>): T[] | undefined {

--- a/packages/serialization/form/src/formParseNode.ts
+++ b/packages/serialization/form/src/formParseNode.ts
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { BackingStoreFactory, createBackedModelProxyHandler, DateOnly, Duration, type Parsable, type ParsableFactory, parseGuidString, type ParseNode, TimeOnly, isBackingStoreEnabled, getEnumValueFromStringValue } from "@microsoft/kiota-abstractions";
+import { BackingStoreFactory, createBackedModelProxyHandler, DateOnly, Duration, type Parsable, type ParsableFactory, parseGuidString, type ParseNode, TimeOnly, isBackingStoreEnabled, getEnumValueFromStringValue, type PrimitiveTypesForDeserialization } from "@microsoft/kiota-abstractions";
 
 export class FormParseNode implements ParseNode {
 	private readonly _fields: Record<string, string> = {};
@@ -86,26 +86,26 @@ export class FormParseNode implements ParseNode {
 	public getDateOnlyValue = () => this.getDateOnlyValueFromRaw(this._rawString);
 	public getTimeOnlyValue = () => this.getTimeOnlyValueFromRaw(this._rawString);
 	public getDurationValue = () => this.getDurationValueFromRaw(this._rawString);
-	public getCollectionOfPrimitiveValues = <T>(): T[] | undefined => {
+	public getCollectionOfPrimitiveValues = <T>(primitiveType: Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer"> = "string"): T[] | undefined => {
 		const values = this._rawString.split(",");
-		return (values as unknown[]).map((x) => {
-			const typeOfX = typeof x;
-			if (typeOfX === "boolean") {
-				return this.getBooleanValueFromRaw(x as string) as unknown as T;
-			} else if (typeOfX === "string") {
-				return this.getStringValueFromRaw(x as string) as unknown as T;
-			} else if (typeOfX === "number") {
-				return this.getNumberValueFromRaw(x as string) as unknown as T;
-			} else if (x instanceof Date) {
-				return this.getDateValueFromRaw(x as unknown as string) as unknown as T;
-			} else if (x instanceof DateOnly) {
-				return this.getDateOnlyValueFromRaw(x as unknown as string) as unknown as T;
-			} else if (x instanceof TimeOnly) {
-				return this.getTimeOnlyValueFromRaw(x as unknown as string) as unknown as T;
-			} else if (x instanceof Duration) {
-				return this.getDurationValueFromRaw(x as unknown as string) as unknown as T;
-			} else {
-				throw new Error(`encountered an unknown type during deserialization ${typeof x}`);
+		return values.map((x) => {
+			switch (primitiveType) {
+				case "boolean":
+					return this.getBooleanValueFromRaw(x) as unknown as T;
+				case "number":
+					return this.getNumberValueFromRaw(x) as unknown as T;
+				case "Date":
+					return this.getDateValueFromRaw(x) as unknown as T;
+				case "DateOnly":
+					return this.getDateOnlyValueFromRaw(x) as unknown as T;
+				case "TimeOnly":
+					return this.getTimeOnlyValueFromRaw(x) as unknown as T;
+				case "Duration":
+					return this.getDurationValueFromRaw(x) as unknown as T;
+				case "string":
+					return this.getStringValueFromRaw(x) as unknown as T;
+				default:
+					throw new Error(`encountered an unsupported type during deserialization ${primitiveType as string}`);
 			}
 		});
 	};

--- a/packages/serialization/form/src/formParseNode.ts
+++ b/packages/serialization/form/src/formParseNode.ts
@@ -86,7 +86,7 @@ export class FormParseNode implements ParseNode {
 	public getDateOnlyValue = () => this.getDateOnlyValueFromRaw(this._rawString);
 	public getTimeOnlyValue = () => this.getTimeOnlyValueFromRaw(this._rawString);
 	public getDurationValue = () => this.getDurationValueFromRaw(this._rawString);
-	public getCollectionOfPrimitiveValues = <T>(primitiveType: PrimitiveTypesForDeserializationForCollection = "string"): T[] | undefined => {
+	public getCollectionOfPrimitiveValues = <T>(primitiveType: PrimitiveTypesForDeserializationForCollection): T[] | undefined => {
 		const values = this._rawString.split(",");
 		return values.map((x) => {
 			switch (primitiveType) {

--- a/packages/serialization/form/src/formParseNode.ts
+++ b/packages/serialization/form/src/formParseNode.ts
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { BackingStoreFactory, createBackedModelProxyHandler, DateOnly, Duration, type Parsable, type ParsableFactory, parseGuidString, type ParseNode, TimeOnly, isBackingStoreEnabled, getEnumValueFromStringValue, type PrimitiveTypesForDeserialization } from "@microsoft/kiota-abstractions";
+import { BackingStoreFactory, createBackedModelProxyHandler, DateOnly, Duration, type Parsable, type ParsableFactory, parseGuidString, type ParseNode, TimeOnly, isBackingStoreEnabled, getEnumValueFromStringValue, type PrimitiveTypesForDeserializationForCollection } from "@microsoft/kiota-abstractions";
 
 export class FormParseNode implements ParseNode {
 	private readonly _fields: Record<string, string> = {};
@@ -86,7 +86,7 @@ export class FormParseNode implements ParseNode {
 	public getDateOnlyValue = () => this.getDateOnlyValueFromRaw(this._rawString);
 	public getTimeOnlyValue = () => this.getTimeOnlyValueFromRaw(this._rawString);
 	public getDurationValue = () => this.getDurationValueFromRaw(this._rawString);
-	public getCollectionOfPrimitiveValues = <T>(primitiveType: Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer"> = "string"): T[] | undefined => {
+	public getCollectionOfPrimitiveValues = <T>(primitiveType: PrimitiveTypesForDeserializationForCollection = "string"): T[] | undefined => {
 		const values = this._rawString.split(",");
 		return values.map((x) => {
 			switch (primitiveType) {

--- a/packages/serialization/form/test/common/formParseNode.ts
+++ b/packages/serialization/form/test/common/formParseNode.ts
@@ -73,12 +73,12 @@ describe("FormParseNode", () => {
 		const enumValueResult3 = new FormParseNode("IN PROGRESS").getEnumValue(Test_statusObject) as Test_status;
 		assert.equal(enumValueResult3, Test_statusObject.INPROGRESS);
 	});
-	it("getCollectionOfPrimitiveValues returns decoded string values by default", () => {
-		const result = new FormParseNode("one,two,three").getCollectionOfPrimitiveValues<string>();
+	it("getCollectionOfPrimitiveValues returns decoded string values for explicit string primitive", () => {
+		const result = new FormParseNode("one,two,three").getCollectionOfPrimitiveValues<string>("string");
 		assert.deepEqual(result, ["one", "two", "three"]);
 	});
-	it("getCollectionOfPrimitiveValues returns string values by default when elements look typed", () => {
-		const result = new FormParseNode("1,true,2023-01-01").getCollectionOfPrimitiveValues<string>();
+	it("getCollectionOfPrimitiveValues returns string values when requested and elements look typed", () => {
+		const result = new FormParseNode("1,true,2023-01-01").getCollectionOfPrimitiveValues<string>("string");
 		assert.deepEqual(result, ["1", "true", "2023-01-01"]);
 	});
 	it("getCollectionOfPrimitiveValues returns decoded string values when requested", () => {

--- a/packages/serialization/form/test/common/formParseNode.ts
+++ b/packages/serialization/form/test/common/formParseNode.ts
@@ -7,6 +7,7 @@
 
 import { assert, describe, it } from "vitest";
 
+import { DateOnly, TimeOnly } from "@microsoft/kiota-abstractions";
 import { FormParseNode } from "../../src/index";
 import { createTestParserFromDiscriminatorValue, type TestEntity } from "../testEntity";
 
@@ -72,24 +73,47 @@ describe("FormParseNode", () => {
 		const enumValueResult3 = new FormParseNode("IN PROGRESS").getEnumValue(Test_statusObject) as Test_status;
 		assert.equal(enumValueResult3, Test_statusObject.INPROGRESS);
 	});
-	it("getCollectionOfPrimitiveValues returns decoded string values (only string collections are supported with URI encoding)", () => {
+	it("getCollectionOfPrimitiveValues returns decoded string values by default", () => {
 		const result = new FormParseNode("one,two,three").getCollectionOfPrimitiveValues<string>();
 		assert.deepEqual(result, ["one", "two", "three"]);
 	});
-	it("getCollectionOfPrimitiveValues returns string values even when elements look like numbers (only string collections are supported)", () => {
-		const result = new FormParseNode("1,2,3").getCollectionOfPrimitiveValues<string>();
-		assert.deepEqual(result, ["1", "2", "3"]);
+	it("getCollectionOfPrimitiveValues returns string values by default when elements look typed", () => {
+		const result = new FormParseNode("1,true,2023-01-01").getCollectionOfPrimitiveValues<string>();
+		assert.deepEqual(result, ["1", "true", "2023-01-01"]);
 	});
-	it("getCollectionOfPrimitiveValues returns string values even when elements look like booleans (only string collections are supported)", () => {
-		const result = new FormParseNode("true,false,true").getCollectionOfPrimitiveValues<string>();
-		assert.deepEqual(result, ["true", "false", "true"]);
-	});
-	it("getCollectionOfPrimitiveValues returns string values even when elements look like dates (only string collections are supported)", () => {
-		const result = new FormParseNode("2023-01-01,2023-06-15").getCollectionOfPrimitiveValues<string>();
-		assert.deepEqual(result, ["2023-01-01", "2023-06-15"]);
-	});
-	it("getCollectionOfPrimitiveValues URL-decodes percent-encoded characters", () => {
-		const result = new FormParseNode("hello%20world,foo%26bar").getCollectionOfPrimitiveValues<string>();
+	it("getCollectionOfPrimitiveValues returns decoded string values when requested", () => {
+		const result = new FormParseNode("hello%20world,foo%26bar").getCollectionOfPrimitiveValues<string>("string");
 		assert.deepEqual(result, ["hello world", "foo&bar"]);
+	});
+	it("getCollectionOfPrimitiveValues returns number values when requested", () => {
+		const result = new FormParseNode("1,2.5,3").getCollectionOfPrimitiveValues<number>("number");
+		assert.deepEqual(result, [1, 2.5, 3]);
+	});
+	it("getCollectionOfPrimitiveValues returns boolean values when requested", () => {
+		const result = new FormParseNode("true,0,1,false").getCollectionOfPrimitiveValues<boolean>("boolean");
+		assert.deepEqual(result, [true, false, true, false]);
+	});
+	it("getCollectionOfPrimitiveValues returns Date values when requested", () => {
+		const result = new FormParseNode("2023-01-01T00%3A00%3A00.000Z,2023-06-15T00%3A00%3A00.000Z").getCollectionOfPrimitiveValues<Date>("Date");
+		assert.deepEqual(
+			result?.map((x) => x.toISOString()),
+			["2023-01-01T00:00:00.000Z", "2023-06-15T00:00:00.000Z"],
+		);
+	});
+	it("getCollectionOfPrimitiveValues returns DateOnly values when requested", () => {
+		const result = new FormParseNode("2023-01-01,2023-06-15").getCollectionOfPrimitiveValues<DateOnly>("DateOnly");
+		assert.deepEqual(
+			result?.map((x) => x.toString()),
+			["2023-01-01", "2023-06-15"],
+		);
+		assert.instanceOf(result?.[0], DateOnly);
+	});
+	it("getCollectionOfPrimitiveValues returns TimeOnly values when requested", () => {
+		const result = new FormParseNode("08%3A00%3A00.0000000,17%3A30%3A00.0000000").getCollectionOfPrimitiveValues<TimeOnly>("TimeOnly");
+		assert.deepEqual(
+			result?.map((x) => x.toString()),
+			["08:00:00.0000000", "17:30:00.0000000"],
+		);
+		assert.instanceOf(result?.[0], TimeOnly);
 	});
 });

--- a/packages/serialization/form/test/testEntity.ts
+++ b/packages/serialization/form/test/testEntity.ts
@@ -58,7 +58,7 @@ export function deserializeTestEntity(testEntity: TestEntity | undefined = {}): 
 			testEntity.officeLocation = n.getStringValue();
 		},
 		deviceNames: (n) => {
-			testEntity.deviceNames = n.getCollectionOfPrimitiveValues();
+			testEntity.deviceNames = n.getCollectionOfPrimitiveValues("string");
 		},
 		status: (n) => {
 			testEntity.status = n.getEnumValue<LongRunningOperationStatus>(LongRunningOperationStatusObject);

--- a/packages/serialization/json/src/jsonParseNode.ts
+++ b/packages/serialization/json/src/jsonParseNode.ts
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { BackingStoreFactory, DateOnly, Duration, TimeOnly, UntypedNode, createBackedModelProxyHandler, createUntypedArray, createUntypedBoolean, createUntypedNodeFromDiscriminatorValue, createUntypedNull, createUntypedNumber, createUntypedObject, createUntypedString, inNodeEnv, isBackingStoreEnabled, isUntypedNode, parseGuidString, getEnumValueFromStringValue, type Parsable, type ParsableFactory, type ParseNode, AdditionalDataHolder, type PrimitiveTypesForDeserialization } from "@microsoft/kiota-abstractions";
+import { BackingStoreFactory, DateOnly, Duration, TimeOnly, UntypedNode, createBackedModelProxyHandler, createUntypedArray, createUntypedBoolean, createUntypedNodeFromDiscriminatorValue, createUntypedNull, createUntypedNumber, createUntypedObject, createUntypedString, inNodeEnv, isBackingStoreEnabled, isUntypedNode, parseGuidString, getEnumValueFromStringValue, type Parsable, type ParsableFactory, type ParseNode, AdditionalDataHolder, type PrimitiveTypesForDeserializationForCollection } from "@microsoft/kiota-abstractions";
 
 export class JsonParseNode implements ParseNode {
 	/**
@@ -55,11 +55,14 @@ export class JsonParseNode implements ParseNode {
 	public getDateOnlyValue = () => this.getDateOnlyValueFromRaw(this._jsonNode);
 	public getTimeOnlyValue = () => this.getTimeOnlyValueFromRaw(this._jsonNode);
 	public getDurationValue = () => this.getDurationValueFromRaw(this._jsonNode);
-	public getCollectionOfPrimitiveValues = <T>(_primitiveType?: Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer">): T[] | undefined => {
+	public getCollectionOfPrimitiveValues = <T>(primitiveType?: PrimitiveTypesForDeserializationForCollection): T[] | undefined => {
 		if (!Array.isArray(this._jsonNode)) {
 			return undefined;
 		}
 		return (this._jsonNode as unknown[]).map((x) => {
+			if (primitiveType) {
+				return this.getPrimitiveValue<T>(x, primitiveType);
+			}
 			const typeOfX = typeof x;
 			if (x === null) {
 				return null as T;
@@ -81,6 +84,38 @@ export class JsonParseNode implements ParseNode {
 				throw new Error(`encountered an unknown type during deserialization ${typeof x}`);
 			}
 		});
+	};
+	private getPrimitiveValue = <T>(value: unknown, primitiveType: PrimitiveTypesForDeserializationForCollection): T => {
+		if (value === null) {
+			return null as T;
+		}
+		switch (primitiveType) {
+			case "boolean":
+				if (typeof value !== "boolean") {
+					throw new Error(`encountered an unsupported type during deserialization ${typeof value}`);
+				}
+				return value as unknown as T;
+			case "number":
+				if (typeof value !== "number") {
+					throw new Error(`encountered an unsupported type during deserialization ${typeof value}`);
+				}
+				return value as unknown as T;
+			case "Date":
+				return this.getDateValueFromRaw(value) as unknown as T;
+			case "DateOnly":
+				return this.getDateOnlyValueFromRaw(value) as unknown as T;
+			case "TimeOnly":
+				return this.getTimeOnlyValueFromRaw(value) as unknown as T;
+			case "Duration":
+				return this.getDurationValueFromRaw(value) as unknown as T;
+			case "string":
+				if (typeof value !== "string") {
+					throw new Error(`encountered an unsupported type during deserialization ${typeof value}`);
+				}
+				return value as unknown as T;
+			default:
+				throw new Error(`encountered an unsupported type during deserialization ${primitiveType as string}`);
+		}
 	};
 	public getByteArrayValue(): ArrayBuffer | undefined {
 		const strValue = this.getStringValue();

--- a/packages/serialization/json/src/jsonParseNode.ts
+++ b/packages/serialization/json/src/jsonParseNode.ts
@@ -55,35 +55,11 @@ export class JsonParseNode implements ParseNode {
 	public getDateOnlyValue = () => this.getDateOnlyValueFromRaw(this._jsonNode);
 	public getTimeOnlyValue = () => this.getTimeOnlyValueFromRaw(this._jsonNode);
 	public getDurationValue = () => this.getDurationValueFromRaw(this._jsonNode);
-	public getCollectionOfPrimitiveValues = <T>(primitiveType?: PrimitiveTypesForDeserializationForCollection): T[] | undefined => {
+	public getCollectionOfPrimitiveValues = <T>(primitiveType: PrimitiveTypesForDeserializationForCollection = "string"): T[] | undefined => {
 		if (!Array.isArray(this._jsonNode)) {
 			return undefined;
 		}
-		return (this._jsonNode as unknown[]).map((x) => {
-			if (primitiveType) {
-				return this.getPrimitiveValue<T>(x, primitiveType);
-			}
-			const typeOfX = typeof x;
-			if (x === null) {
-				return null as T;
-			} else if (typeOfX === "boolean") {
-				return x as unknown as T;
-			} else if (typeOfX === "string") {
-				return x as unknown as T;
-			} else if (typeOfX === "number") {
-				return x as unknown as T;
-			} else if (x instanceof Date) {
-				return this.getDateValueFromRaw(x) as unknown as T;
-			} else if (x instanceof DateOnly) {
-				return this.getDateOnlyValueFromRaw(x) as unknown as T;
-			} else if (x instanceof TimeOnly) {
-				return this.getTimeOnlyValueFromRaw(x) as unknown as T;
-			} else if (x instanceof Duration) {
-				return this.getDurationValueFromRaw(x) as unknown as T;
-			} else {
-				throw new Error(`encountered an unknown type during deserialization ${typeof x}`);
-			}
-		});
+		return (this._jsonNode as unknown[]).map((x) => this.getPrimitiveValue<T>(x, primitiveType));
 	};
 	private readonly getPrimitiveValue = <T>(value: unknown, primitiveType: PrimitiveTypesForDeserializationForCollection): T => {
 		if (value === null) {

--- a/packages/serialization/json/src/jsonParseNode.ts
+++ b/packages/serialization/json/src/jsonParseNode.ts
@@ -55,7 +55,7 @@ export class JsonParseNode implements ParseNode {
 	public getDateOnlyValue = () => this.getDateOnlyValueFromRaw(this._jsonNode);
 	public getTimeOnlyValue = () => this.getTimeOnlyValueFromRaw(this._jsonNode);
 	public getDurationValue = () => this.getDurationValueFromRaw(this._jsonNode);
-	public getCollectionOfPrimitiveValues = <T>(primitiveType: PrimitiveTypesForDeserializationForCollection = "string"): T[] | undefined => {
+	public getCollectionOfPrimitiveValues = <T>(primitiveType: PrimitiveTypesForDeserializationForCollection): T[] | undefined => {
 		if (!Array.isArray(this._jsonNode)) {
 			return undefined;
 		}

--- a/packages/serialization/json/src/jsonParseNode.ts
+++ b/packages/serialization/json/src/jsonParseNode.ts
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { BackingStoreFactory, DateOnly, Duration, TimeOnly, UntypedNode, createBackedModelProxyHandler, createUntypedArray, createUntypedBoolean, createUntypedNodeFromDiscriminatorValue, createUntypedNull, createUntypedNumber, createUntypedObject, createUntypedString, inNodeEnv, isBackingStoreEnabled, isUntypedNode, parseGuidString, getEnumValueFromStringValue, type Parsable, type ParsableFactory, type ParseNode, AdditionalDataHolder } from "@microsoft/kiota-abstractions";
+import { BackingStoreFactory, DateOnly, Duration, TimeOnly, UntypedNode, createBackedModelProxyHandler, createUntypedArray, createUntypedBoolean, createUntypedNodeFromDiscriminatorValue, createUntypedNull, createUntypedNumber, createUntypedObject, createUntypedString, inNodeEnv, isBackingStoreEnabled, isUntypedNode, parseGuidString, getEnumValueFromStringValue, type Parsable, type ParsableFactory, type ParseNode, AdditionalDataHolder, type PrimitiveTypesForDeserialization } from "@microsoft/kiota-abstractions";
 
 export class JsonParseNode implements ParseNode {
 	/**
@@ -55,7 +55,7 @@ export class JsonParseNode implements ParseNode {
 	public getDateOnlyValue = () => this.getDateOnlyValueFromRaw(this._jsonNode);
 	public getTimeOnlyValue = () => this.getTimeOnlyValueFromRaw(this._jsonNode);
 	public getDurationValue = () => this.getDurationValueFromRaw(this._jsonNode);
-	public getCollectionOfPrimitiveValues = <T>(): T[] | undefined => {
+	public getCollectionOfPrimitiveValues = <T>(_primitiveType?: Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer">): T[] | undefined => {
 		if (!Array.isArray(this._jsonNode)) {
 			return undefined;
 		}

--- a/packages/serialization/json/src/jsonParseNode.ts
+++ b/packages/serialization/json/src/jsonParseNode.ts
@@ -85,7 +85,7 @@ export class JsonParseNode implements ParseNode {
 			}
 		});
 	};
-	private getPrimitiveValue = <T>(value: unknown, primitiveType: PrimitiveTypesForDeserializationForCollection): T => {
+	private readonly getPrimitiveValue = <T>(value: unknown, primitiveType: PrimitiveTypesForDeserializationForCollection): T => {
 		if (value === null) {
 			return null as T;
 		}

--- a/packages/serialization/json/test/common/JsonParseNode.ts
+++ b/packages/serialization/json/test/common/JsonParseNode.ts
@@ -9,7 +9,7 @@ import { assert, beforeEach, describe, it } from "vitest";
 import { JsonParseNode } from "../../src/index";
 import { createTestParserFromDiscriminatorValue, type TestBackedModel, createTestBackedModelFromDiscriminatorValue, type TestParser, TestUnionObject, BarResponse } from "./testEntity";
 import { UntypedTestEntity, createUntypedTestEntityFromDiscriminatorValue } from "./untypedTestEntity";
-import { BackingStoreFactory, BackingStore, InMemoryBackingStoreFactory, UntypedNode, UntypedObject, isUntypedArray, isUntypedBoolean, isUntypedNode, isUntypedNumber, isUntypedObject } from "@microsoft/kiota-abstractions";
+import { BackingStoreFactory, BackingStore, InMemoryBackingStoreFactory, UntypedNode, UntypedObject, isUntypedArray, isUntypedBoolean, isUntypedNode, isUntypedNumber, isUntypedObject, DateOnly, TimeOnly, Duration } from "@microsoft/kiota-abstractions";
 
 describe("JsonParseNode", () => {
 	let backingStoreFactory: BackingStoreFactory;
@@ -365,6 +365,40 @@ describe("JsonParseNode", () => {
 	it("getCollectionOfPrimitiveValues returns string values when elements are date-like strings", () => {
 		const result = new JsonParseNode(["2023-01-01", "2023-06-15"], backingStoreFactory).getCollectionOfPrimitiveValues<string>();
 		assert.deepEqual(result, ["2023-01-01", "2023-06-15"]);
+	});
+	it("getCollectionOfPrimitiveValues returns Date values when requested", () => {
+		const result = new JsonParseNode(["2023-01-01T00:00:00.000Z", "2023-06-15T00:00:00.000Z"], backingStoreFactory).getCollectionOfPrimitiveValues<Date>("Date");
+		assert.deepEqual(
+			result?.map((x) => x.toISOString()),
+			["2023-01-01T00:00:00.000Z", "2023-06-15T00:00:00.000Z"],
+		);
+	});
+	it("getCollectionOfPrimitiveValues returns DateOnly values when requested", () => {
+		const result = new JsonParseNode(["2023-01-01", "2023-06-15"], backingStoreFactory).getCollectionOfPrimitiveValues<DateOnly>("DateOnly");
+		assert.deepEqual(
+			result?.map((x) => x.toString()),
+			["2023-01-01", "2023-06-15"],
+		);
+		assert.instanceOf(result?.[0], DateOnly);
+	});
+	it("getCollectionOfPrimitiveValues returns TimeOnly values when requested", () => {
+		const result = new JsonParseNode(["08:00:00.0000000", "17:30:00.0000000"], backingStoreFactory).getCollectionOfPrimitiveValues<TimeOnly>("TimeOnly");
+		assert.deepEqual(
+			result?.map((x) => x.toString()),
+			["08:00:00.0000000", "17:30:00.0000000"],
+		);
+		assert.instanceOf(result?.[0], TimeOnly);
+	});
+	it("getCollectionOfPrimitiveValues returns Duration values when requested", () => {
+		const result = new JsonParseNode(["PT1H", "PT2H"], backingStoreFactory).getCollectionOfPrimitiveValues<Duration>("Duration");
+		assert.deepEqual(
+			result?.map((x) => x.toString()),
+			["PT1H", "PT2H"],
+		);
+		assert.instanceOf(result?.[0], Duration);
+	});
+	it("getCollectionOfPrimitiveValues validates item types when requested", () => {
+		assert.throw(() => new JsonParseNode(["one", 2], backingStoreFactory).getCollectionOfPrimitiveValues<string>("string"), /unsupported type/);
 	});
 	it("getCollectionOfPrimitiveValues returns null for null elements in array", () => {
 		const result = new JsonParseNode(["hello", null, "world"], backingStoreFactory).getCollectionOfPrimitiveValues<string | null>();

--- a/packages/serialization/json/test/common/JsonParseNode.ts
+++ b/packages/serialization/json/test/common/JsonParseNode.ts
@@ -347,7 +347,7 @@ describe("JsonParseNode", () => {
 	});
 
 	it("getCollectionOfPrimitiveValues returns string values", () => {
-		const result = new JsonParseNode(["one", "two", "three"], backingStoreFactory).getCollectionOfPrimitiveValues<string>();
+		const result = new JsonParseNode(["one", "two", "three"], backingStoreFactory).getCollectionOfPrimitiveValues<string>("string");
 		assert.deepEqual(result, ["one", "two", "three"]);
 	});
 	it("getCollectionOfPrimitiveValues returns number values when elements are numbers", () => {
@@ -363,7 +363,7 @@ describe("JsonParseNode", () => {
 		assert.deepEqual(result, [true, false, true]);
 	});
 	it("getCollectionOfPrimitiveValues returns string values when elements are date-like strings", () => {
-		const result = new JsonParseNode(["2023-01-01", "2023-06-15"], backingStoreFactory).getCollectionOfPrimitiveValues<string>();
+		const result = new JsonParseNode(["2023-01-01", "2023-06-15"], backingStoreFactory).getCollectionOfPrimitiveValues<string>("string");
 		assert.deepEqual(result, ["2023-01-01", "2023-06-15"]);
 	});
 	it("getCollectionOfPrimitiveValues returns Date values when requested", () => {
@@ -401,7 +401,7 @@ describe("JsonParseNode", () => {
 		assert.throw(() => new JsonParseNode(["one", 2], backingStoreFactory).getCollectionOfPrimitiveValues<string>("string"), /unsupported type/);
 	});
 	it("getCollectionOfPrimitiveValues returns null for null elements in array", () => {
-		const result = new JsonParseNode(["hello", null, "world"], backingStoreFactory).getCollectionOfPrimitiveValues<string | null>();
+		const result = new JsonParseNode(["hello", null, "world"], backingStoreFactory).getCollectionOfPrimitiveValues<string | null>("string");
 		assert.deepEqual(result, ["hello", null, "world"]);
 	});
 

--- a/packages/serialization/json/test/common/JsonParseNode.ts
+++ b/packages/serialization/json/test/common/JsonParseNode.ts
@@ -354,6 +354,10 @@ describe("JsonParseNode", () => {
 		const result = new JsonParseNode([1, 2, 3], backingStoreFactory).getCollectionOfPrimitiveValues<number>();
 		assert.deepEqual(result, [1, 2, 3]);
 	});
+	it("getCollectionOfPrimitiveValues accepts a runtime primitive type without changing JSON values", () => {
+		const result = new JsonParseNode([1, 2, 3], backingStoreFactory).getCollectionOfPrimitiveValues<number>("number");
+		assert.deepEqual(result, [1, 2, 3]);
+	});
 	it("getCollectionOfPrimitiveValues returns boolean values when elements are booleans", () => {
 		const result = new JsonParseNode([true, false, true], backingStoreFactory).getCollectionOfPrimitiveValues<boolean>();
 		assert.deepEqual(result, [true, false, true]);

--- a/packages/serialization/json/test/common/JsonParseNode.ts
+++ b/packages/serialization/json/test/common/JsonParseNode.ts
@@ -351,7 +351,7 @@ describe("JsonParseNode", () => {
 		assert.deepEqual(result, ["one", "two", "three"]);
 	});
 	it("getCollectionOfPrimitiveValues returns number values when elements are numbers", () => {
-		const result = new JsonParseNode([1, 2, 3], backingStoreFactory).getCollectionOfPrimitiveValues<number>();
+		const result = new JsonParseNode([1, 2, 3], backingStoreFactory).getCollectionOfPrimitiveValues<number>("number");
 		assert.deepEqual(result, [1, 2, 3]);
 	});
 	it("getCollectionOfPrimitiveValues accepts a runtime primitive type without changing JSON values", () => {
@@ -359,7 +359,7 @@ describe("JsonParseNode", () => {
 		assert.deepEqual(result, [1, 2, 3]);
 	});
 	it("getCollectionOfPrimitiveValues returns boolean values when elements are booleans", () => {
-		const result = new JsonParseNode([true, false, true], backingStoreFactory).getCollectionOfPrimitiveValues<boolean>();
+		const result = new JsonParseNode([true, false, true], backingStoreFactory).getCollectionOfPrimitiveValues<boolean>("boolean");
 		assert.deepEqual(result, [true, false, true]);
 	});
 	it("getCollectionOfPrimitiveValues returns string values when elements are date-like strings", () => {

--- a/packages/serialization/json/test/common/testEntity.ts
+++ b/packages/serialization/json/test/common/testEntity.ts
@@ -83,7 +83,7 @@ export function deserializeTestParser(testParser: TestParser | undefined = {}): 
 			testParser.testObject = n.getObjectValue<{ additionalData?: Record<string, unknown> }>(createTestObjectFromDiscriminatorValue);
 		},
 		"testCollection": (n) => {
-			testParser.testCollection = n.getCollectionOfPrimitiveValues();
+			testParser.testCollection = n.getCollectionOfPrimitiveValues("string");
 		},
 		"testString": (n) => {
 			testParser.testString = n.getStringValue();

--- a/packages/serialization/text/src/textParseNode.ts
+++ b/packages/serialization/text/src/textParseNode.ts
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { DateOnly, Duration, type Parsable, type ParsableFactory, parseGuidString, type ParseNode, TimeOnly, inNodeEnv, getEnumValueFromStringValue } from "@microsoft/kiota-abstractions";
+import { DateOnly, Duration, type Parsable, type ParsableFactory, parseGuidString, type ParseNode, TimeOnly, inNodeEnv, getEnumValueFromStringValue, type PrimitiveTypesForDeserialization } from "@microsoft/kiota-abstractions";
 
 /**
  * This class represents a text parse node.
@@ -58,7 +58,7 @@ export class TextParseNode implements ParseNode {
 	public getDateOnlyValue = () => DateOnly.parse(this.getStringValue());
 	public getTimeOnlyValue = () => TimeOnly.parse(this.getStringValue());
 	public getDurationValue = () => Duration.parse(this.getStringValue());
-	public getCollectionOfPrimitiveValues = <T>(): T[] | undefined => {
+	public getCollectionOfPrimitiveValues = <T>(_primitiveType?: Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer">): T[] | undefined => {
 		throw new Error(TextParseNode.noStructuredDataMessage);
 	};
 	/* eslint-disable @typescript-eslint/no-unused-vars */

--- a/packages/serialization/text/src/textParseNode.ts
+++ b/packages/serialization/text/src/textParseNode.ts
@@ -5,7 +5,7 @@
  * -------------------------------------------------------------------------------------------
  */
 
-import { DateOnly, Duration, type Parsable, type ParsableFactory, parseGuidString, type ParseNode, TimeOnly, inNodeEnv, getEnumValueFromStringValue, type PrimitiveTypesForDeserialization } from "@microsoft/kiota-abstractions";
+import { DateOnly, Duration, type Parsable, type ParsableFactory, parseGuidString, type ParseNode, TimeOnly, inNodeEnv, getEnumValueFromStringValue, type PrimitiveTypesForDeserializationForCollection } from "@microsoft/kiota-abstractions";
 
 /**
  * This class represents a text parse node.
@@ -58,7 +58,8 @@ export class TextParseNode implements ParseNode {
 	public getDateOnlyValue = () => DateOnly.parse(this.getStringValue());
 	public getTimeOnlyValue = () => TimeOnly.parse(this.getStringValue());
 	public getDurationValue = () => Duration.parse(this.getStringValue());
-	public getCollectionOfPrimitiveValues = <T>(_primitiveType?: Exclude<PrimitiveTypesForDeserialization, "ArrayBuffer">): T[] | undefined => {
+	public getCollectionOfPrimitiveValues = <T>(primitiveType?: PrimitiveTypesForDeserializationForCollection): T[] | undefined => {
+		void primitiveType;
 		throw new Error(TextParseNode.noStructuredDataMessage);
 	};
 	/* eslint-disable @typescript-eslint/no-unused-vars */

--- a/packages/serialization/text/src/textParseNode.ts
+++ b/packages/serialization/text/src/textParseNode.ts
@@ -58,9 +58,28 @@ export class TextParseNode implements ParseNode {
 	public getDateOnlyValue = () => DateOnly.parse(this.getStringValue());
 	public getTimeOnlyValue = () => TimeOnly.parse(this.getStringValue());
 	public getDurationValue = () => Duration.parse(this.getStringValue());
-	public getCollectionOfPrimitiveValues = <T>(primitiveType?: PrimitiveTypesForDeserializationForCollection): T[] | undefined => {
-		void primitiveType;
-		throw new Error(TextParseNode.noStructuredDataMessage);
+	public getCollectionOfPrimitiveValues = <T>(primitiveType: PrimitiveTypesForDeserializationForCollection = "string"): T[] | undefined => {
+		return this.text.split(",").map((x) => {
+			const node = new TextParseNode(x);
+			switch (primitiveType) {
+				case "boolean":
+					return node.getBooleanValue() as unknown as T;
+				case "number":
+					return node.getNumberValue() as unknown as T;
+				case "Date":
+					return node.getDateValue() as unknown as T;
+				case "DateOnly":
+					return node.getDateOnlyValue() as unknown as T;
+				case "TimeOnly":
+					return node.getTimeOnlyValue() as unknown as T;
+				case "Duration":
+					return node.getDurationValue() as unknown as T;
+				case "string":
+					return node.getStringValue() as unknown as T;
+				default:
+					throw new Error(`encountered an unsupported type during deserialization ${primitiveType as string}`);
+			}
+		});
 	};
 	/* eslint-disable @typescript-eslint/no-unused-vars */
 	public getCollectionOfObjectValues<T extends Parsable>(parsableFactory: ParsableFactory<T>): T[] | undefined {

--- a/packages/serialization/text/src/textParseNode.ts
+++ b/packages/serialization/text/src/textParseNode.ts
@@ -58,7 +58,7 @@ export class TextParseNode implements ParseNode {
 	public getDateOnlyValue = () => DateOnly.parse(this.getStringValue());
 	public getTimeOnlyValue = () => TimeOnly.parse(this.getStringValue());
 	public getDurationValue = () => Duration.parse(this.getStringValue());
-	public getCollectionOfPrimitiveValues = <T>(primitiveType: PrimitiveTypesForDeserializationForCollection = "string"): T[] | undefined => {
+	public getCollectionOfPrimitiveValues = <T>(primitiveType: PrimitiveTypesForDeserializationForCollection): T[] | undefined => {
 		return this.text.split(",").map((x) => {
 			const node = new TextParseNode(x);
 			switch (primitiveType) {

--- a/packages/serialization/text/test/common/textParseNode.ts
+++ b/packages/serialization/text/test/common/textParseNode.ts
@@ -15,6 +15,10 @@ describe("textParseNode", () => {
 		const textParseNode = new TextParseNode("Test");
 		assert.isDefined(textParseNode);
 	});
+	it("getCollectionOfPrimitiveValues returns number values when requested", () => {
+		const result = new TextParseNode("1,2,3").getCollectionOfPrimitiveValues<number>("number");
+		assert.deepEqual(result, [1, 2, 3]);
+	});
 	it("Test enum values with special or reserved characters", async () => {
 		type Test_status = (typeof Test_statusObject)[keyof typeof Test_statusObject];
 		const Test_statusObject = {

--- a/packages/test/generatedCode/models/index.ts
+++ b/packages/test/generatedCode/models/index.ts
@@ -608,7 +608,7 @@ export function deserializeIntoMessageRule(messageRule: Partial<MessageRule> | u
 // @ts-ignore
 export function deserializeIntoMessageRuleActions(messageRuleActions: Partial<MessageRuleActions> | undefined = {}) : Record<string, (node: ParseNode) => void> {
     return {
-        "assignCategories": n => { messageRuleActions.assignCategories = n.getCollectionOfPrimitiveValues<string>(); },
+        "assignCategories": n => { messageRuleActions.assignCategories = n.getCollectionOfPrimitiveValues<string>("string"); },
         "copyToFolder": n => { messageRuleActions.copyToFolder = n.getStringValue(); },
         "delete": n => { messageRuleActions.delete = n.getBooleanValue(); },
         "forwardAsAttachmentTo": n => { messageRuleActions.forwardAsAttachmentTo = n.getCollectionOfObjectValues<Recipient>(createRecipientFromDiscriminatorValue); },
@@ -629,12 +629,12 @@ export function deserializeIntoMessageRuleActions(messageRuleActions: Partial<Me
 // @ts-ignore
 export function deserializeIntoMessageRulePredicates(messageRulePredicates: Partial<MessageRulePredicates> | undefined = {}) : Record<string, (node: ParseNode) => void> {
     return {
-        "bodyContains": n => { messageRulePredicates.bodyContains = n.getCollectionOfPrimitiveValues<string>(); },
-        "bodyOrSubjectContains": n => { messageRulePredicates.bodyOrSubjectContains = n.getCollectionOfPrimitiveValues<string>(); },
-        "categories": n => { messageRulePredicates.categories = n.getCollectionOfPrimitiveValues<string>(); },
+        "bodyContains": n => { messageRulePredicates.bodyContains = n.getCollectionOfPrimitiveValues<string>("string"); },
+        "bodyOrSubjectContains": n => { messageRulePredicates.bodyOrSubjectContains = n.getCollectionOfPrimitiveValues<string>("string"); },
+        "categories": n => { messageRulePredicates.categories = n.getCollectionOfPrimitiveValues<string>("string"); },
         "fromAddresses": n => { messageRulePredicates.fromAddresses = n.getCollectionOfObjectValues<Recipient>(createRecipientFromDiscriminatorValue); },
         "hasAttachments": n => { messageRulePredicates.hasAttachments = n.getBooleanValue(); },
-        "headerContains": n => { messageRulePredicates.headerContains = n.getCollectionOfPrimitiveValues<string>(); },
+        "headerContains": n => { messageRulePredicates.headerContains = n.getCollectionOfPrimitiveValues<string>("string"); },
         "importance": n => { messageRulePredicates.importance = n.getEnumValue<Importance>(ImportanceObject); },
         "isApprovalRequest": n => { messageRulePredicates.isApprovalRequest = n.getBooleanValue(); },
         "isAutomaticForward": n => { messageRulePredicates.isAutomaticForward = n.getBooleanValue(); },
@@ -649,15 +649,15 @@ export function deserializeIntoMessageRulePredicates(messageRulePredicates: Part
         "isVoicemail": n => { messageRulePredicates.isVoicemail = n.getBooleanValue(); },
         "messageActionFlag": n => { messageRulePredicates.messageActionFlag = n.getEnumValue<MessageActionFlag>(MessageActionFlagObject); },
         "notSentToMe": n => { messageRulePredicates.notSentToMe = n.getBooleanValue(); },
-        "recipientContains": n => { messageRulePredicates.recipientContains = n.getCollectionOfPrimitiveValues<string>(); },
-        "senderContains": n => { messageRulePredicates.senderContains = n.getCollectionOfPrimitiveValues<string>(); },
+        "recipientContains": n => { messageRulePredicates.recipientContains = n.getCollectionOfPrimitiveValues<string>("string"); },
+        "senderContains": n => { messageRulePredicates.senderContains = n.getCollectionOfPrimitiveValues<string>("string"); },
         "sensitivity": n => { messageRulePredicates.sensitivity = n.getEnumValue<Sensitivity>(SensitivityObject); },
         "sentCcMe": n => { messageRulePredicates.sentCcMe = n.getBooleanValue(); },
         "sentOnlyToMe": n => { messageRulePredicates.sentOnlyToMe = n.getBooleanValue(); },
         "sentToAddresses": n => { messageRulePredicates.sentToAddresses = n.getCollectionOfObjectValues<Recipient>(createRecipientFromDiscriminatorValue); },
         "sentToMe": n => { messageRulePredicates.sentToMe = n.getBooleanValue(); },
         "sentToOrCcMe": n => { messageRulePredicates.sentToOrCcMe = n.getBooleanValue(); },
-        "subjectContains": n => { messageRulePredicates.subjectContains = n.getCollectionOfPrimitiveValues<string>(); },
+        "subjectContains": n => { messageRulePredicates.subjectContains = n.getCollectionOfPrimitiveValues<string>("string"); },
         "withinSizeRange": n => { messageRulePredicates.withinSizeRange = n.getObjectValue<SizeRange>(createSizeRangeFromDiscriminatorValue); },
     }
 }
@@ -670,7 +670,7 @@ export function deserializeIntoMessageRulePredicates(messageRulePredicates: Part
 export function deserializeIntoMultiValueLegacyExtendedProperty(multiValueLegacyExtendedProperty: Partial<MultiValueLegacyExtendedProperty> | undefined = {}) : Record<string, (node: ParseNode) => void> {
     return {
         ...deserializeIntoEntity(multiValueLegacyExtendedProperty),
-        "value": n => { multiValueLegacyExtendedProperty.value = n.getCollectionOfPrimitiveValues<string>(); },
+        "value": n => { multiValueLegacyExtendedProperty.value = n.getCollectionOfPrimitiveValues<string>("string"); },
     }
 }
 /**
@@ -682,7 +682,7 @@ export function deserializeIntoMultiValueLegacyExtendedProperty(multiValueLegacy
 export function deserializeIntoOutlookItem(outlookItem: Partial<OutlookItem> | undefined = {}) : Record<string, (node: ParseNode) => void> {
     return {
         ...deserializeIntoEntity(outlookItem),
-        "categories": n => { outlookItem.categories = n.getCollectionOfPrimitiveValues<string>(); },
+        "categories": n => { outlookItem.categories = n.getCollectionOfPrimitiveValues<string>("string"); },
         "changeKey": n => { outlookItem.changeKey = n.getStringValue(); },
         "createdDateTime": n => { outlookItem.createdDateTime = n.getDateValue(); },
         "lastModifiedDateTime": n => { outlookItem.lastModifiedDateTime = n.getDateValue(); },
@@ -732,7 +732,7 @@ export function deserializeIntoSizeRange(sizeRange: Partial<SizeRange> | undefin
 export function deserializeIntoUploadSession(uploadSession: Partial<UploadSession> | undefined = {}) : Record<string, (node: ParseNode) => void> {
     return {
         "expirationDateTime": n => { uploadSession.expirationDateTime = n.getDateValue(); },
-        "nextExpectedRanges": n => { uploadSession.nextExpectedRanges = n.getCollectionOfPrimitiveValues<string>(); },
+        "nextExpectedRanges": n => { uploadSession.nextExpectedRanges = n.getCollectionOfPrimitiveValues<string>("string"); },
         "uploadUrl": n => { uploadSession.uploadUrl = n.getStringValue(); },
     }
 }


### PR DESCRIPTION
Closes #2000.

This updates `ParseNode.getCollectionOfPrimitiveValues` to accept an optional runtime primitive type, while keeping the no-argument call path compatible. The form parse node now uses that runtime type to deserialize comma-separated primitive collections as strings, numbers, booleans, dates, `DateOnly`, `TimeOnly`, or `Duration`. JSON and text parse nodes accept the same parameter so the interface stays consistent; JSON keeps returning the already-decoded values.

The fetch request adapter now passes the requested primitive response type into collection deserialization, including `Duration`, `DateOnly`, and `TimeOnly` collection response types.

Validation run locally:
- `npm --workspace @microsoft/kiota-abstractions run build`
- `npm --workspace @microsoft/kiota-serialization-form run test:node`
- `npm --workspace @microsoft/kiota-serialization-json run test:node`
- `npm --workspace @microsoft/kiota-serialization-form run build`
- `npm --workspace @microsoft/kiota-serialization-json run build`
- `npm --workspace @microsoft/kiota-serialization-text run build`
- `npm --workspace @microsoft/kiota-http-fetchlibrary run build`
- `npm run prettier:check`
- `npx eslint --quiet packages/abstractions/src/serialization/parseNode.ts packages/http/fetch/src/fetchRequestAdapter.ts packages/serialization/form/src/formParseNode.ts packages/serialization/json/src/jsonParseNode.ts packages/serialization/text/src/textParseNode.ts`
- `git diff --check`

I also ran `npm run lint`; it still reports an existing unrelated error in `packages/bundle/src/defaultRequestAdapter.ts`.