### PR TITLE
Fix S360 open-source vulnerabilities (SFI-ES5.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/sinon": "^22.0.0",
         "@typescript-eslint/eslint-plugin": "^8.1.0",
         "@typescript-eslint/parser": "^8.1.0",
-        "@vitest/browser": "^4.0.1",
+        "@vitest/browser": "^4.1.8",
         "@vitest/coverage-istanbul": "^4.0.1",
         "@vitest/coverage-v8": "^4.0.1",
         "@vitest/ui": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,16 @@
     "string_decoder": "^1.3.0",
     "lodash": "^4.18.1",
     "basic-ftp": "^5.2.2",
-    "axios": "^1.15.1",
-    "vite": "^7.3.2",
+    "axios": "^1.16.0",
+    "vite": "^7.3.5",
     "@azure/msal-node": "^5.1.5",
-    "keyv": "^5.5.3"
+    "keyv": "^5.5.3",
+    "fast-uri": "^3.1.2",
+    "fast-xml-builder": "^1.1.7",
+    "form-data": "^4.0.6",
+    "sigstore": "^4.1.1",
+    "tmp": "^0.2.6",
+    "ws": "^8.21.0"
   },
   "devDependencies": {
     "@microsoft/eslint-config-msgraph": "^5.0.0",
@@ -17,7 +23,7 @@
     "@types/sinon": "^22.0.0",
     "@typescript-eslint/eslint-plugin": "^8.1.0",
     "@typescript-eslint/parser": "^8.1.0",
-    "@vitest/browser": "^4.0.1",
+    "@vitest/browser": "^4.1.8",
     "@vitest/coverage-istanbul": "^4.0.1",
     "@vitest/coverage-v8": "^4.0.1",
     "@vitest/ui": "^4.0.1",


### PR DESCRIPTION
## Summary

Remediates S360 KPI `[SFI-ES5.2] 1ES Open Source Vulnerabilities (Operational)` by tightening the direct `@vitest/browser` dev dependency and adding/updating root npm `overrides` for vulnerable transitive dependencies.

| Package | Old vulnerable version | Patched resolved version | Change |
| --- | ---: | ---: | --- |
| `@vitest/browser` | 4.1.2 | 4.1.10 | direct range `^4.1.8` |
| `axios` | 1.13.6 | 1.18.1 | override `^1.16.0` |
| `basic-ftp` | 5.2.0 | 5.3.1 | override `^5.2.2` |
| `fast-uri` | 3.1.0 | 3.1.3 | override `^3.1.2` |
| `fast-xml-builder` | 1.1.4 | 1.2.0 | override `^1.1.7` |
| `form-data` | 4.0.5 | 4.0.6 | override `^4.0.6` |
| `lodash` | 4.17.23 | 4.18.1 | override `^4.18.1` |
| `sigstore` | 4.1.0 | 4.1.1 | override `^4.1.1` |
| `tmp` | 0.2.5 | 0.2.7 | override `^0.2.6` |
| `vite` | 7.1.11 | 7.3.6 | override `^7.3.5` |
| `ws` | 8.19.0 | 8.21.0 | override `^8.21.0` |

## CVEs / advisories covered

- `@vitest/browser`: CVE-2026-47428, CVE-2026-53633
- `axios`: CVE-2026-42043, CVE-2026-44488, CVE-2026-42264, CVE-2026-42035, CVE-2026-44494, CVE-2026-44487, CVE-2026-42033, CVE-2026-44486
- `basic-ftp`: GHSA-6v7q-wjvx-w8wg, CVE-2026-39983
- `fast-uri`: CVE-2026-6322, CVE-2026-6321
- `fast-xml-builder`: CVE-2026-44665
- `form-data`: CVE-2026-12143
- `lodash`: CVE-2026-4800
- `sigstore`: CVE-2026-48815
- `tmp`: CVE-2026-44705
- `vite`: CVE-2026-39363, CVE-2026-53571, CVE-2026-39364
- `ws`: CVE-2026-48779

## Validation

- `npm install --registry=https://registry.npmjs.org/` completed; default configured Microsoft package feed returned 404 for `vite-7.3.6.tgz`, so npmjs registry was used for install validation.
- `npm ls --include=dev @vitest/browser axios basic-ftp fast-uri fast-xml-builder form-data lodash sigstore tmp vite ws` confirmed patched resolved versions.
- `npm run build` failed at pre-existing `prettier:check` formatting warnings in `packages/http/fetch/**` before compilation.
- `npm run build:@microsoft/*` passed.
- `npm test` passed.

## Skipped items

None.