### PR TITLE
Support map-style query parameters (type: object + additionalProperties)

### DIFF
--- a/packages/abstractions/src/requestInformation.ts
+++ b/packages/abstractions/src/requestInformation.ts
@@ -65,12 +65,12 @@ export class RequestInformation implements RequestInformationSetContent {
 			const data = {} as Record<string, unknown>;
 			for (const key in this.queryParameters) {
 				if (this.queryParameters[key] !== null && this.queryParameters[key] !== undefined) {
-					data[key] = this.normalizeValue(this.queryParameters[key]);
+					data[key] = RequestInformation.normalizeValue(this.queryParameters[key]);
 				}
 			}
 			for (const key in this.pathParameters) {
 				if (this.pathParameters[key] !== null && this.pathParameters[key] !== undefined) {
-					data[key] = this.normalizeValue(this.pathParameters[key]);
+					data[key] = RequestInformation.normalizeValue(this.pathParameters[key]);
 				}
 			}
 			return StdUriTemplate.expand(this.urlTemplate, data);
@@ -89,9 +89,7 @@ export class RequestInformation implements RequestInformationSetContent {
 	/** The Request Body. */
 	public content?: ArrayBuffer;
 	/** The Query Parameters of the request. */
-	public queryParameters: Record<string, string | number | boolean | string[] | number[] | Record<string, string | null> | undefined> = createRecordWithCaseInsensitiveKeys<
-		string | number | boolean | string[] | number[] | Record<string, string | null> | undefined
-	>();
+	public queryParameters: Record<string, string | number | boolean | string[] | number[] | Record<string, unknown> | undefined> = createRecordWithCaseInsensitiveKeys<string | number | boolean | string[] | number[] | Record<string, unknown> | undefined>();
 	/** The Request Headers. */
 	public headers: Headers = new Headers();
 	private _requestOptions: Record<string, RequestOption> = createRecordWithCaseInsensitiveKeys<RequestOption>();
@@ -241,7 +239,12 @@ export class RequestInformation implements RequestInformationSetContent {
 		this.content = value;
 	};
 
-	private normalizeValue(value: unknown): unknown {
+	/**
+	 * Normalizes a value for URI template expansion.
+	 * @param value The value to normalize.
+	 * @returns The normalized value.
+	 */
+	private static normalizeValue(value: unknown): unknown {
 		if (value instanceof DateOnly || value instanceof TimeOnly || value instanceof Duration) {
 			return value.toString();
 		}
@@ -249,7 +252,7 @@ export class RequestInformation implements RequestInformationSetContent {
 			return value.toISOString();
 		}
 		if (Array.isArray(value)) {
-			return value.map((val) => this.normalizeValue(val));
+			return value.map((val) => RequestInformation.normalizeValue(val));
 		}
 		if (typeof value === "object" && value !== null) {
 			return RequestInformation.sanitizeMapValue(value as Record<string, unknown>);
@@ -261,13 +264,14 @@ export class RequestInformation implements RequestInformationSetContent {
 	 * Pre-processes a plain-object dictionary for StdUriTemplate expansion.
 	 * Null/undefined values are omitted: RFC 6570 §2.3 treats "undefined" variables
 	 * as absent (no output). Use "" to send ?key= (empty value).
+	 * @param map The map to sanitize.
+	 * @returns The sanitized map with null/undefined values omitted and values normalized.
 	 */
-	private static sanitizeMapValue(map: Record<string, unknown>): Record<string, string> {
-		const result: Record<string, string> = {};
-		for (const key in map) {
-			const v = map[key];
+	private static sanitizeMapValue(map: Record<string, unknown>): Record<string, unknown> {
+		const result: Record<string, unknown> = {};
+		for (const [key, v] of Object.entries(map)) {
 			if (v !== null && v !== undefined) {
-				result[key] = String(v);
+				result[key] = RequestInformation.normalizeValue(v);
 			}
 		}
 		return result;
@@ -291,7 +295,7 @@ export class RequestInformation implements RequestInformationSetContent {
 			else if (v instanceof DateOnly || v instanceof TimeOnly || v instanceof Duration) this.queryParameters[key] = v.toString();
 			else if (v instanceof Date) this.queryParameters[key] = v.toISOString();
 			else if (v === undefined) this.queryParameters[key] = undefined;
-			else if (typeof v === "object" && v !== null) this.queryParameters[key] = v as Record<string, string | null>;
+			else if (typeof v === "object" && v !== null) this.queryParameters[key] = v as Record<string, unknown>;
 		});
 	}
 	/**

--- a/packages/abstractions/src/requestInformation.ts
+++ b/packages/abstractions/src/requestInformation.ts
@@ -89,7 +89,9 @@ export class RequestInformation implements RequestInformationSetContent {
 	/** The Request Body. */
 	public content?: ArrayBuffer;
 	/** The Query Parameters of the request. */
-	public queryParameters: Record<string, string | number | boolean | string[] | number[] | undefined> = createRecordWithCaseInsensitiveKeys<string | number | boolean | string[] | number[] | undefined>();
+	public queryParameters: Record<string, string | number | boolean | string[] | number[] | Record<string, string | null> | undefined> = createRecordWithCaseInsensitiveKeys<
+		string | number | boolean | string[] | number[] | Record<string, string | null> | undefined
+	>();
 	/** The Request Headers. */
 	public headers: Headers = new Headers();
 	private _requestOptions: Record<string, RequestOption> = createRecordWithCaseInsensitiveKeys<RequestOption>();
@@ -249,7 +251,26 @@ export class RequestInformation implements RequestInformationSetContent {
 		if (Array.isArray(value)) {
 			return value.map((val) => this.normalizeValue(val));
 		}
+		if (typeof value === "object" && value !== null) {
+			return RequestInformation.sanitizeMapValue(value as Record<string, unknown>);
+		}
 		return value;
+	}
+
+	/**
+	 * Pre-processes a plain-object dictionary for StdUriTemplate expansion.
+	 * Null/undefined values are omitted: RFC 6570 §2.3 treats "undefined" variables
+	 * as absent (no output). Use "" to send ?key= (empty value).
+	 */
+	private static sanitizeMapValue(map: Record<string, unknown>): Record<string, string> {
+		const result: Record<string, string> = {};
+		for (const key in map) {
+			const v = map[key];
+			if (v !== null && v !== undefined) {
+				result[key] = String(v);
+			}
+		}
+		return result;
 	}
 	/**
 	 * Sets the query string parameters from a raw object.
@@ -270,6 +291,7 @@ export class RequestInformation implements RequestInformationSetContent {
 			else if (v instanceof DateOnly || v instanceof TimeOnly || v instanceof Duration) this.queryParameters[key] = v.toString();
 			else if (v instanceof Date) this.queryParameters[key] = v.toISOString();
 			else if (v === undefined) this.queryParameters[key] = undefined;
+			else if (typeof v === "object" && v !== null) this.queryParameters[key] = v as Record<string, string | null>;
 		});
 	}
 	/**

--- a/packages/abstractions/test/common/requestInformation.ts
+++ b/packages/abstractions/test/common/requestInformation.ts
@@ -26,7 +26,7 @@ interface GetQueryParameters {
 	endDate?: DateOnly;
 	timeStamp?: Date;
 	duration?: Duration;
-	query?: Record<string, string | null>;
+	query?: Record<string, unknown>;
 }
 
 const getQueryParameterMapper: Record<string, string> = {
@@ -404,5 +404,21 @@ describe("RequestInformation", () => {
 		const url = requestInformation.URL;
 		assert.include(url, "%24top=5");
 		assert.include(url, "filter=active");
+	});
+
+	it("Supports map query parameter with numbers, booleans, and Date objects", () => {
+		const requestInformation = new RequestInformation();
+		requestInformation.urlTemplate = "http://localhost/articles{?query*}";
+		requestInformation.setQueryStringParametersFromRawObject<GetQueryParameters>({
+			query: {
+				page: 2,
+				active: true,
+				created: new Date("2026-07-24T00:00:00.000Z"),
+			},
+		});
+		const url = requestInformation.URL;
+		assert.include(url, "page=2");
+		assert.include(url, "active=true");
+		assert.include(url, "created=2026-07-24T00%3A00%3A00.000Z");
 	});
 });

--- a/packages/abstractions/test/common/requestInformation.ts
+++ b/packages/abstractions/test/common/requestInformation.ts
@@ -26,6 +26,7 @@ interface GetQueryParameters {
 	endDate?: DateOnly;
 	timeStamp?: Date;
 	duration?: Duration;
+	query?: Record<string, string | null>;
 }
 
 const getQueryParameterMapper: Record<string, string> = {
@@ -310,5 +311,98 @@ describe("RequestInformation", () => {
 		const contentTypeHeaderValue = requestInformation.headers.tryGetValue("Content-Type")![0];
 		assert.equal(contentTypeHeaderValue, `multipart/form-data; boundary=${mpBody.getBoundary()}`);
 		assert.isNotEmpty(mpBody.getBoundary());
+	});
+
+	it("Expands map query parameter as individual key-value pairs (RFC 6570 {?query*})", () => {
+		const requestInformation = new RequestInformation();
+		requestInformation.urlTemplate = "http://localhost/articles{?query*}";
+		requestInformation.setQueryStringParametersFromRawObject<GetQueryParameters>({
+			query: {
+				filter: "equals(published,true)",
+				sort: "-createdAt",
+			},
+		});
+		const url = requestInformation.URL;
+		// RFC 6570 {?query*} expands a map as individual key=value pairs; order is not guaranteed.
+		// JavaScript's encodeURIComponent does not encode ( or ) — only , becomes %2C.
+		assert.include(url, "?");
+		assert.include(url, "filter=equals(published%2Ctrue)");
+		assert.include(url, "sort=-createdAt");
+	});
+
+	it("Skips null values when expanding map query parameter", () => {
+		const requestInformation = new RequestInformation();
+		requestInformation.urlTemplate = "http://localhost/articles{?query*}";
+		requestInformation.setQueryStringParametersFromRawObject<GetQueryParameters>({
+			query: {
+				filter: "equals(published,true)",
+				sort: null,
+			},
+		});
+		const url = requestInformation.URL;
+		assert.include(url, "filter=equals(published%2Ctrue)");
+		assert.notInclude(url, "sort");
+	});
+
+	it("Preserves empty string values in map query parameter (sends ?key=)", () => {
+		const requestInformation = new RequestInformation();
+		requestInformation.urlTemplate = "http://localhost/articles{?query*}";
+		requestInformation.setQueryStringParametersFromRawObject<GetQueryParameters>({
+			query: { filter: "" },
+		});
+		const url = requestInformation.URL;
+		assert.include(url, "filter=");
+	});
+
+	it("Omits map query parameter entirely when all entries are null", () => {
+		const requestInformation = new RequestInformation();
+		requestInformation.urlTemplate = "http://localhost/articles{?query*}";
+		requestInformation.setQueryStringParametersFromRawObject<GetQueryParameters>({
+			query: { filter: null, sort: null },
+		});
+		assert.equal(requestInformation.URL, "http://localhost/articles");
+	});
+
+	it("Omits map query parameter entirely when the map is empty", () => {
+		const requestInformation = new RequestInformation();
+		requestInformation.urlTemplate = "http://localhost/articles{?query*}";
+		requestInformation.setQueryStringParametersFromRawObject<GetQueryParameters>({ query: {} });
+		assert.equal(requestInformation.URL, "http://localhost/articles");
+	});
+
+	it("Supports map query parameter set directly on queryParameters", () => {
+		const requestInformation = new RequestInformation();
+		requestInformation.urlTemplate = "http://localhost/articles{?query*}";
+		requestInformation.queryParameters["query"] = {
+			include: "author",
+			"page[size]": "10",
+		};
+		const url = requestInformation.URL;
+		assert.include(url, "include=author");
+		assert.include(url, "page%5Bsize%5D=10");
+	});
+
+	it("Does not throw when map query parameter contains null values set directly", () => {
+		const requestInformation = new RequestInformation();
+		requestInformation.urlTemplate = "http://localhost/articles{?query*}";
+		requestInformation.queryParameters["query"] = {
+			filter: "value",
+			sort: null,
+		};
+		assert.doesNotThrow(() => {
+			const url = requestInformation.URL;
+			assert.include(url, "filter=value");
+			assert.notInclude(url, "sort");
+		});
+	});
+
+	it("Mixes map query parameter with regular scalar query parameters", () => {
+		const requestInformation = new RequestInformation();
+		requestInformation.urlTemplate = "http://localhost/articles{?%24top,query*}";
+		requestInformation.queryParameters["%24top"] = 5;
+		requestInformation.queryParameters["query"] = { filter: "active" };
+		const url = requestInformation.URL;
+		assert.include(url, "%24top=5");
+		assert.include(url, "filter=active");
 	});
 });


### PR DESCRIPTION
Contributes to https://github.com/microsoft/kiota/issues/3800.

Extend RequestInformation to handle plain-object (dictionary) query parameter values so that RFC 6570 {?param*} templates expand them into individual key=value pairs, matching OAS 4.8.12.1 behaviour for exploded form-style query parameters.

Three gaps are closed:
- queryParameters now accepts Record<string, string | null> entries.
- setQueryStringParametersFromRawObject stores plain-object values instead of silently ignoring them.
- normalizeValue routes objects through the new sanitizeMapValue helper, which strips null/undefined entries before they reach StdUriTemplate (null values would otherwise cause convertNativeTypes to throw because typeof null === "object").

Null-entry semantics follow RFC 6570 para 2.3: an undefined/null value produces no output; use "" to emit ?key= (empty value present).