### PR TITLE
feat(http-fetchlibrary): export defaultScrubSensitiveHeaders for comp…

### DIFF
--- a/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
@@ -76,11 +76,8 @@ export const defaultScrubSensitiveHeaders: ScrubSensitiveHeaders = (headers: Rec
 		return;
 	}
 
-	// Note: Proxy-Authorization is not handled here as proxy configuration in Fetch API
-	// is managed by the browser/runtime and not accessible to JavaScript code.
-	// In environments where this matters (e.g., Node.js with custom agents), the proxy
-	// configuration should be managed at the HTTP client level.
-};
+	// Note: In browser environments, `Proxy-Authorization` is a forbidden header name and typically cannot be set.
+	// The logic above still removes it if present (e.g., in Node.js or other non-browser runtimes).
 
 /**
  * MiddlewareOptions

--- a/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
@@ -34,6 +34,55 @@ export interface RedirectHandlerOptionsParams {
 }
 
 /**
+ * The default implementation for scrubbing sensitive headers during redirects.
+ * This function removes Authorization, Cookie, and Proxy-Authorization headers when the host or scheme changes.
+ *
+ * It is exported so that consumers providing a custom {@link ScrubSensitiveHeaders} callback can call it to
+ * retain the default behavior and then layer additional logic on top (e.g. removing custom headers such as
+ * `X-Api-Key`), matching the composable pattern available in the .NET and Python Kiota SDKs.
+ *
+ * Note: Proxy-Authorization handling is not applicable in Fetch API as proxy configuration
+ * is handled at a lower level by the browser/runtime and is not accessible to JavaScript.
+ * @param headers - The headers object to modify
+ * @param originalUrl - The original request URL
+ * @param newUrl - The new redirect URL
+ */
+export const defaultScrubSensitiveHeaders: ScrubSensitiveHeaders = (headers: Record<string, string>, originalUrl: string, newUrl: string) => {
+	if (!headers || !originalUrl || !newUrl) {
+		return;
+	}
+
+	try {
+		const originalUri = new URL(originalUrl);
+		const newUri = new URL(newUrl);
+
+		// Remove Authorization, Cookie, and Proxy-Authorization headers if the request's scheme or host changes.
+		// Header keys must be matched case-insensitively because FetchRequestAdapter.getRequestFromRequestInformation
+		// lower-cases every header key before the headers object reaches this middleware, so PascalCase
+		// property deletes such as `delete headers.Authorization` would otherwise be a no-op.
+		const isDifferentHostOrScheme = originalUri.host.toLowerCase() !== newUri.host.toLowerCase() || originalUri.protocol.toLowerCase() !== newUri.protocol.toLowerCase();
+
+		if (isDifferentHostOrScheme) {
+			for (const key of Object.keys(headers)) {
+				const lower = key.toLowerCase();
+				if (lower === "authorization" || lower === "cookie" || lower === "proxy-authorization") {
+					delete headers[key];
+				}
+			}
+		}
+	} catch {
+		// If URL parsing fails, don't modify headers
+		// This handles cases where invalid URLs are passed
+		return;
+	}
+
+	// Note: Proxy-Authorization is not handled here as proxy configuration in Fetch API
+	// is managed by the browser/runtime and not accessible to JavaScript code.
+	// In environments where this matters (e.g., Node.js with custom agents), the proxy
+	// configuration should be managed at the HTTP client level.
+};
+
+/**
  * MiddlewareOptions
  * A class representing RedirectHandlerOptions
  */
@@ -56,48 +105,10 @@ export class RedirectHandlerOptions implements RequestOption {
 	private static readonly defaultShouldRetry: ShouldRedirect = () => true;
 
 	/**
-	 * The default implementation for scrubbing sensitive headers during redirects.
-	 * This method removes Authorization and Cookie headers when the host or scheme changes.
-	 * Note: Proxy-Authorization handling is not applicable in Fetch API as proxy configuration
-	 * is handled at a lower level by the browser/runtime and is not accessible to JavaScript.
-	 * @param headers - The headers object to modify
-	 * @param originalUrl - The original request URL
-	 * @param newUrl - The new redirect URL
+	 * The default {@link ScrubSensitiveHeaders} callback used when none is supplied.
+	 * Delegates to the exported {@link defaultScrubSensitiveHeaders} function.
 	 */
-	private static readonly defaultScrubSensitiveHeaders: ScrubSensitiveHeaders = (headers: Record<string, string>, originalUrl: string, newUrl: string) => {
-		if (!headers || !originalUrl || !newUrl) {
-			return;
-		}
-
-		try {
-			const originalUri = new URL(originalUrl);
-			const newUri = new URL(newUrl);
-
-			// Remove Authorization, Cookie, and Proxy-Authorization headers if the request's scheme or host changes.
-			// Header keys must be matched case-insensitively because FetchRequestAdapter.getRequestFromRequestInformation
-			// lower-cases every header key before the headers object reaches this middleware, so PascalCase
-			// property deletes such as `delete headers.Authorization` would otherwise be a no-op.
-			const isDifferentHostOrScheme = originalUri.host.toLowerCase() !== newUri.host.toLowerCase() || originalUri.protocol.toLowerCase() !== newUri.protocol.toLowerCase();
-
-			if (isDifferentHostOrScheme) {
-				for (const key of Object.keys(headers)) {
-					const lower = key.toLowerCase();
-					if (lower === "authorization" || lower === "cookie" || lower === "proxy-authorization") {
-						delete headers[key];
-					}
-				}
-			}
-		} catch {
-			// If URL parsing fails, don't modify headers
-			// This handles cases where invalid URLs are passed
-			return;
-		}
-
-		// Note: Proxy-Authorization is not handled here as proxy configuration in Fetch API
-		// is managed by the browser/runtime and not accessible to JavaScript code.
-		// In environments where this matters (e.g., Node.js with custom agents), the proxy
-		// configuration should be managed at the HTTP client level.
-	};
+	private static readonly defaultScrubSensitiveHeaders: ScrubSensitiveHeaders = defaultScrubSensitiveHeaders;
 
 	/**
 	 *

--- a/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
+++ b/packages/http/fetch/src/middlewares/options/redirectHandlerOptions.ts
@@ -41,8 +41,8 @@ export interface RedirectHandlerOptionsParams {
  * retain the default behavior and then layer additional logic on top (e.g. removing custom headers such as
  * `X-Api-Key`), matching the composable pattern available in the .NET and Python Kiota SDKs.
  *
- * Note: Proxy-Authorization handling is not applicable in Fetch API as proxy configuration
- * is handled at a lower level by the browser/runtime and is not accessible to JavaScript.
+ * Note: In browser environments, `Proxy-Authorization` is a forbidden header name and typically cannot be set;
+ * it is still removed here if present (e.g. in Node.js or other non-browser runtimes).
  * @param headers - The headers object to modify
  * @param originalUrl - The original request URL
  * @param newUrl - The new redirect URL
@@ -75,9 +75,7 @@ export const defaultScrubSensitiveHeaders: ScrubSensitiveHeaders = (headers: Rec
 		// This handles cases where invalid URLs are passed
 		return;
 	}
-
-	// Note: In browser environments, `Proxy-Authorization` is a forbidden header name and typically cannot be set.
-	// The logic above still removes it if present (e.g., in Node.js or other non-browser runtimes).
+};
 
 /**
  * MiddlewareOptions

--- a/packages/http/fetch/test/node/RedirectHandlerOptions.ts
+++ b/packages/http/fetch/test/node/RedirectHandlerOptions.ts
@@ -8,6 +8,7 @@
 import { assert, describe, it } from "vitest";
 
 import { RedirectHandlerOptions } from "../../src/middlewares/options/redirectHandlerOptions";
+import { defaultScrubSensitiveHeaders } from "../../src/middlewares/options/redirectHandlerOptions";
 
 describe("RedirectHandlerOptions.ts", () => {
 	describe("constructor", () => {
@@ -113,6 +114,61 @@ describe("RedirectHandlerOptions.ts", () => {
 			RedirectHandlerOptions["defaultScrubSensitiveHeaders"](null as any, "https://example.com", "https://other.com");
 			RedirectHandlerOptions["defaultScrubSensitiveHeaders"]({} as any, null as any, "https://other.com");
 			RedirectHandlerOptions["defaultScrubSensitiveHeaders"]({} as any, "https://example.com", null as any);
+		});
+	});
+
+	describe("exported defaultScrubSensitiveHeaders", () => {
+		it("Should be the same implementation used as the class default", () => {
+			const options = new RedirectHandlerOptions();
+			assert.equal(options.scrubSensitiveHeaders, defaultScrubSensitiveHeaders);
+		});
+
+		it("Should remove Authorization, Cookie and Proxy-Authorization headers when host changes", () => {
+			const headers = {
+				authorization: "******",
+				cookie: "session=SECRET",
+				"proxy-authorization": "******",
+				"content-type": "application/json",
+			};
+			defaultScrubSensitiveHeaders(headers, "https://graph.microsoft.com/v1.0/me", "https://evil.attacker.com/steal");
+			assert.isUndefined(headers.authorization);
+			assert.isUndefined(headers.cookie);
+			assert.isUndefined(headers["proxy-authorization"]);
+			assert.isDefined(headers["content-type"]); // Other headers should remain
+		});
+
+		it("Should be composable with custom scrubbing logic", () => {
+			const scrubSensitiveHeaders = (headers: Record<string, string>, originalUrl: string, newUrl: string) => {
+				// Preserve the default behavior
+				defaultScrubSensitiveHeaders(headers, originalUrl, newUrl);
+
+				// Then remove additional custom headers on host/scheme change
+				const originalUri = new URL(originalUrl);
+				const newUri = new URL(newUrl);
+				const isDifferentHostOrScheme = originalUri.host.toLowerCase() !== newUri.host.toLowerCase() || originalUri.protocol.toLowerCase() !== newUri.protocol.toLowerCase();
+				if (isDifferentHostOrScheme) {
+					for (const key of Object.keys(headers)) {
+						const lower = key.toLowerCase();
+						if (lower === "x-api-key" || lower === "x-custom-auth") {
+							delete headers[key];
+						}
+					}
+				}
+			};
+
+			const headers = {
+				authorization: "******",
+				cookie: "session=SECRET",
+				"x-api-key": "custom-secret",
+				"x-custom-auth": "custom-secret",
+				"content-type": "application/json",
+			};
+			scrubSensitiveHeaders(headers, "https://graph.microsoft.com/v1.0/me", "https://evil.attacker.com/steal");
+			assert.isUndefined(headers.authorization);
+			assert.isUndefined(headers.cookie);
+			assert.isUndefined(headers["x-api-key"]);
+			assert.isUndefined(headers["x-custom-auth"]);
+			assert.isDefined(headers["content-type"]);
 		});
 	});
 });

--- a/packages/http/fetch/test/node/RedirectHandlerOptions.ts
+++ b/packages/http/fetch/test/node/RedirectHandlerOptions.ts
@@ -7,8 +7,7 @@
 
 import { assert, describe, it } from "vitest";
 
-import { RedirectHandlerOptions } from "../../src/middlewares/options/redirectHandlerOptions";
-import { defaultScrubSensitiveHeaders } from "../../src/middlewares/options/redirectHandlerOptions";
+import { RedirectHandlerOptions, defaultScrubSensitiveHeaders } from "../../src/middlewares/options/redirectHandlerOptions";
 
 describe("RedirectHandlerOptions.ts", () => {
 	describe("constructor", () => {


### PR DESCRIPTION
This PR extracts the default redirect header scrubbing logic into an exported module-level `defaultScrubSensitiveHeaders` function so consumers providing a custom ScrubSensitiveHeaders callback can invoke the default and layer additional logic (e.g. removing custom headers such as X-Api-Key) on top.

Previously the default was a private static member and could not be reused,forcing consumers to reimplement it. This matches the composable pattern already available in the .NET (DefaultScrubSensitiveHeaders) and Python (default_scrub_sensitive_headers) Kiota SDKs. The class default now delegates to the exported function, so existing behavior is unchanged.