### PR TITLE
fix(abstractions): accept defined falsy multipart content

### DIFF
--- a/packages/abstractions/src/multipartBody.ts
+++ b/packages/abstractions/src/multipartBody.ts
@@ -25,7 +25,7 @@ export class MultipartBody implements Parsable {
 	 * Adds or replaces a part with the given name, content type and content.
 	 * @param partName the name of the part to add or replace.
 	 * @param partContentType the content type of the part to add or replace.
-	 * @param content the content of the part to add or replace.
+	 * @param content the content of the part to add or replace. Must not be undefined.
 	 * @param serializationCallback the serialization callback to use when serializing the part.
 	 * @param fileName the name of the file associated with this part.
 	 */
@@ -34,7 +34,7 @@ export class MultipartBody implements Parsable {
 		if (!partContentType) {
 			throw new Error("partContentType cannot be undefined");
 		}
-		if (!content) throw new Error("content cannot be undefined");
+		if (content === undefined) throw new Error("content cannot be undefined");
 		const normalizePartName = this.normalizePartName(partName);
 		this._parts[normalizePartName] = {
 			contentType: partContentType,

--- a/packages/abstractions/test/common/multipartBody.ts
+++ b/packages/abstractions/test/common/multipartBody.ts
@@ -14,7 +14,7 @@ describe("multipartBody", () => {
 		const mpBody = new MultipartBody();
 		assert.throws(() => mpBody.addOrReplacePart("", "application/json", "test"), Error, "partName cannot be undefined");
 		assert.throws(() => mpBody.addOrReplacePart("test", "", "test"), Error, "partContentType cannot be undefined");
-		assert.throws(() => mpBody.addOrReplacePart("test", "application/json", ""), Error, "content cannot be undefined");
+		assert.throws(() => mpBody.addOrReplacePart("test", "application/json", undefined), Error, "content cannot be undefined");
 		assert.throws(() => mpBody.getPartValue(""), Error, "partName cannot be undefined");
 		assert.throws(() => mpBody.removePart(""), Error, "partName cannot be undefined");
 		assert.throws(() => serializeMultipartBody(undefined as any as SerializationWriter, mpBody), Error, "writer cannot be undefined");
@@ -37,6 +37,25 @@ describe("multipartBody", () => {
 		assert.strictEqual(mpBody.getPartValue("test"), "test");
 		mpBody.removePart("test");
 		assert.strictEqual(mpBody.getPartValue("test"), undefined);
+	});
+	it.each(["", 0, 0n, false, null])("adds defined falsy content: %s", (content) => {
+		const mpBody = new MultipartBody();
+		mpBody.addOrReplacePart("test", "application/json", content);
+		assert.strictEqual(mpBody.getPartValue("test"), content);
+		assert.isTrue(mpBody.removePart("test"));
+	});
+	it.each(["", 0, 0n, false, null])("replaces a part with defined falsy content: %s", (content) => {
+		const mpBody = new MultipartBody();
+		mpBody.addOrReplacePart("test", "application/json", "original");
+		mpBody.addOrReplacePart("TEST", "application/json", content);
+		assert.strictEqual(mpBody.getPartValue("test"), content);
+		assert.deepEqual(Object.keys(mpBody.listParts()), ["test"]);
+	});
+	it("preserves an existing part when undefined content is rejected", () => {
+		const mpBody = new MultipartBody();
+		mpBody.addOrReplacePart("test", "text/plain", "original");
+		assert.throws(() => mpBody.addOrReplacePart("test", "text/plain", undefined), Error, "content cannot be undefined");
+		assert.strictEqual(mpBody.getPartValue("test"), "original");
 	});
 	//serialize method is tested in the serialization library
 });

--- a/packages/serialization/multipart/test/common/multipartSerializationWriter.ts
+++ b/packages/serialization/multipart/test/common/multipartSerializationWriter.ts
@@ -65,6 +65,25 @@ describe("MultipartSerializationWriter", () => {
 		const expectedString = `--${mpBody.getBoundary()}\r\nContent-Type: text/plain\r\nContent-Disposition: form-data; name="testPart"\r\n\r\ntest content\r\n--${mpBody.getBoundary()}--\r\n`;
 		assert.equal(result, expectedString);
 	});
+	it("serializes an empty string part", () => {
+		const mpBody = new MultipartBody();
+		mpBody.addOrReplacePart("empty", "text/plain", "");
+		const writer = new MultipartSerializationWriter();
+		writer.writeObjectValue(undefined, mpBody, serializeMultipartBody);
+		const result = new TextDecoder().decode(writer.getSerializedContent());
+		assert.equal(result, `--${mpBody.getBoundary()}\r\nContent-Type: text/plain\r\nContent-Disposition: form-data; name="empty"\r\n\r\n\r\n--${mpBody.getBoundary()}--\r\n`);
+	});
+	it("preserves delimiters around an empty string part", () => {
+		const mpBody = new MultipartBody();
+		mpBody.addOrReplacePart("first", "text/plain", "before");
+		mpBody.addOrReplacePart("empty", "text/plain", "");
+		mpBody.addOrReplacePart("last", "text/plain", "after");
+		const writer = new MultipartSerializationWriter();
+		writer.writeObjectValue(undefined, mpBody, serializeMultipartBody);
+		const result = new TextDecoder().decode(writer.getSerializedContent());
+		const boundary = mpBody.getBoundary();
+		assert.equal(result, `--${boundary}\r\nContent-Type: text/plain\r\nContent-Disposition: form-data; name="first"\r\n\r\nbefore\r\n` + `--${boundary}\r\nContent-Type: text/plain\r\nContent-Disposition: form-data; name="empty"\r\n\r\n\r\n` + `--${boundary}\r\nContent-Type: text/plain\r\nContent-Disposition: form-data; name="last"\r\n\r\nafter\r\n--${boundary}--\r\n`);
+	});
 	it("writes a structured object", () => {
 		const testEntity = {} as TestEntity;
 		testEntity.id = "48d31887-5fad-4d73-a9f5-3c356e68a038";


### PR DESCRIPTION
`MultipartBody.addOrReplacePart()` rejects empty strings, zero, zero bigint, false, and null with “content cannot be undefined.” Its truthiness guard rejects all falsy values rather than only missing content.

Check `content === undefined` and clarify the parameter documentation. Regression tests cover adding and replacing each reported value, preserving an existing part after a rejected undefined replacement, and serializing an empty string alone or between other fields with correct multipart delimiters.

This changes admission of defined content. It does not add scalar serialization support: direct number, bigint, boolean, and null parts remain subject to the existing multipart serializer's type restrictions. Existing valid string/binary/model serialization and part-name/content-type validation retain their behavior.

Validation on Node 22.23.1:

- Before the fix, 10 abstraction regression cases and both empty-string wire-format cases failed.
- `npm ci`: restored the unchanged lockfile.
- `npm run build`, `npm run build:integrated`, `npm run lint:eslint:loud`, and `git diff --check`: passed. Build includes the repository-wide Prettier check.
- `npm test`: both repository scripts passed, each reporting 394 passed and one existing skipped test. The current `test:browser` script does not enable browser mode, so these are not claimed as two distinct browser environments.
- Actual headless Chrome, using an external Vitest configuration with `@vitest/browser-webdriverio@5.0.0`: both affected packages' common suites passed, 111 tests and one existing skip. No browser-tool dependency or configuration change is included in this PR.
- `npx lerna run test:coverage --scope @microsoft/kiota-abstractions --scope @microsoft/kiota-serialization-multipart`: passed.

The full supported Node/platform matrix was not run locally. No dependency or generated-file changes are included.

Closes #2032.

Prepared with AI assistance; reproduction and validation ran locally.
